### PR TITLE
Fix smileys to emojis

### DIFF
--- a/src/components/NewNote/EditBox/EditBox.tsx
+++ b/src/components/NewNote/EditBox/EditBox.tsx
@@ -75,7 +75,7 @@ const EditBox: Component<{
   const [isEmojiInput, setEmojiInput] = createSignal(false);
   const [emojiQuery, setEmojiQuery] = createSignal('');
   const [emojiResults, setEmojiResults] = createStore<EmojiOption[]>([]);
-
+  const [firstEmojiChar, setfirstEmojiChar] = createSignal('');
   const [userRefs, setUserRefs] = createStore<Record<string, PrimalUser>>({});
   const [noteRefs, setNoteRefs] = createStore<Record<string, PrimalNote>>({});
 
@@ -152,8 +152,11 @@ const EditBox: Component<{
       return false;
     }
 
+    // Emojis are only generated when starting with ':' 
     if (!isMentioning() && !isEmojiInput() && e.key === ':') {
       emojiCursorPosition = getCaretCoordinates(textArea, textArea.selectionStart);
+      // Enables searching emojis with ;, 8 etc. in the future (?)
+      setfirstEmojiChar(e.key);
       setEmojiInput(true);
       return false;
     }
@@ -242,6 +245,8 @@ const EditBox: Component<{
           return false;
         }
         e.preventDefault();
+        setEmojiResults(emojiSearch(firstEmojiChar() + emojiQuery()));
+        // highlightedEmoji is always 0 here
         selectEmoji(emojiResults[highlightedEmoji()]);
         setHighlightedEmoji(0);
         return false;

--- a/src/components/NewNote/EditBox/EditBox.tsx
+++ b/src/components/NewNote/EditBox/EditBox.tsx
@@ -75,7 +75,6 @@ const EditBox: Component<{
   const [isEmojiInput, setEmojiInput] = createSignal(false);
   const [emojiQuery, setEmojiQuery] = createSignal('');
   const [emojiResults, setEmojiResults] = createStore<EmojiOption[]>([]);
-  const [firstEmojiChar, setfirstEmojiChar] = createSignal('');
   const [userRefs, setUserRefs] = createStore<Record<string, PrimalUser>>({});
   const [noteRefs, setNoteRefs] = createStore<Record<string, PrimalNote>>({});
 
@@ -155,8 +154,6 @@ const EditBox: Component<{
     // Emojis are only generated when starting with ':' 
     if (!isMentioning() && !isEmojiInput() && e.key === ':') {
       emojiCursorPosition = getCaretCoordinates(textArea, textArea.selectionStart);
-      // Enables searching emojis with ;, 8 etc. in the future (?)
-      setfirstEmojiChar(e.key);
       setEmojiInput(true);
       return false;
     }
@@ -245,7 +242,7 @@ const EditBox: Component<{
           return false;
         }
         e.preventDefault();
-        setEmojiResults(emojiSearch(firstEmojiChar() + emojiQuery()));
+        setEmojiResults(emojiSearch(':' + emojiQuery()));
         // highlightedEmoji is always 0 here
         selectEmoji(emojiResults[highlightedEmoji()]);
         setHighlightedEmoji(0);

--- a/src/components/NewNote/EditBox/EditBox.tsx
+++ b/src/components/NewNote/EditBox/EditBox.tsx
@@ -241,8 +241,7 @@ const EditBox: Component<{
           return false;
         }
         e.preventDefault();
-        setEmojiResults(emojiSearch(':' + emojiQuery()));
-        // highlightedEmoji is always 0 here
+        setEmojiResults(emojiSearch(emojiQuery()));
         selectEmoji(emojiResults[highlightedEmoji()]);
         setHighlightedEmoji(0);
         return false;

--- a/src/components/NewNote/EditBox/EditBox.tsx
+++ b/src/components/NewNote/EditBox/EditBox.tsx
@@ -151,7 +151,6 @@ const EditBox: Component<{
       return false;
     }
 
-    // Emojis are only generated when starting with ':' 
     if (!isMentioning() && !isEmojiInput() && e.key === ':') {
       emojiCursorPosition = getCaretCoordinates(textArea, textArea.selectionStart);
       setEmojiInput(true);

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -472,6 +472,7 @@ const Messages: Component = () => {
           return false;
         }
         e.preventDefault();
+        setEmojiResults(emojiSearch(emojiQuery()));
         selectEmoji(emojiResults[highlightedEmoji()]);
         setHighlightedEmoji(0);
         return false;


### PR DESCRIPTION
- emojiResults[highlightedEmoji()] resulted to undefined causing selectEmoji function to crash. Fixed this by setting emojiResults before calling selectEmoji. 
- - This error also occured in messaging.
- Issue: https://github.com/PrimalHQ/primal-web-app/issues/28

Some notes:
- Added some unnecessary stuff at first and then realized how the code was actually supposed to work.
- If the user doesn't use the toolbox emojiResults[highlightedEmoji()] results into weird behaviour. Typing ":)" or ":D" and pressing space doesn't result to wanted emojis. 
- Writing ;smiley; and pressing space still results to ;smiley;smiley; where the latter ;smiley; turn to emoji. Using ; for demonstration purposes.


I probably should have waited for some conversation under the issue so feel free to disgard this😄