### PR TITLE
Add follow/unfollow button in note context

### DIFF
--- a/src/components/Note/NoteContextMenu.tsx
+++ b/src/components/Note/NoteContextMenu.tsx
@@ -195,7 +195,7 @@ const NoteContextMenu: Component<{
       icon: 'copy_raw_data',
     },
     {
-      label: intl.formatMessage(tActions.noteContext.breadcast),
+      label: intl.formatMessage(tActions.noteContext.broadcast),
       action: broadcastNote,
       icon: 'broadcast',
     },

--- a/src/components/Note/NoteContextMenu.tsx
+++ b/src/components/Note/NoteContextMenu.tsx
@@ -208,8 +208,17 @@ const NoteContextMenu: Component<{
 
   const noteContextForOtherPeople: () => MenuItem[] = () => {
     const isMuted = account?.muted.includes(note()?.user.pubkey);
+    const isFollowed = account?.following.includes(note()?.post.pubkey);
 
     return [
+      {
+        label: isFollowed? intl.formatMessage(tActions.noteContext.unFollowAuthor): intl.formatMessage(tActions.noteContext.followAuthor),
+        action: () => {
+          isFollowed? account?.actions.removeFollow(note()?.post.pubkey) : account?.actions.addFollow(note()?.post.pubkey);
+          props.onClose()
+        },
+        icon: 'default_avatar',
+      },
       {
         label: isMuted ?  intl.formatMessage(tActions.noteContext.unmuteAuthor) : intl.formatMessage(tActions.noteContext.muteAuthor),
         action: () => {
@@ -258,7 +267,6 @@ const NoteContextMenu: Component<{
         }}
         onAbort={() => setConfirmMuteUser(false)}
       />
-
       <PrimalMenu
         id={`note_context_${note()?.post.id}`}
         items={noteContext()}

--- a/src/translations.ts
+++ b/src/translations.ts
@@ -400,8 +400,8 @@ export const actions = {
       defaultMessage: 'Copy user public key',
       description: 'Label for copy note author\'s pubkey from context menu',
     },
-    breadcast: {
-      id: 'actions.noteContext.breadcast',
+    broadcast: {
+      id: 'actions.noteContext.broadcast',
       defaultMessage: 'Broadcast note',
       description: 'Label for note broadcast from context menu',
     },

--- a/src/translations.ts
+++ b/src/translations.ts
@@ -405,6 +405,16 @@ export const actions = {
       defaultMessage: 'Broadcast note',
       description: 'Label for note broadcast from context menu',
     },
+    followAuthor: {
+      id: 'actions.noteContext.follow',
+      defaultMessage: 'Follow',
+      description: 'Label for follow user from context menu',
+    },
+    unFollowAuthor: {
+      id: 'actions.noteContext.unfollow',
+      defaultMessage: 'Unfollow',
+      description: 'Label for unfollow user from context menu',
+    },
     muteAuthor: {
       id: 'actions.noteContext.muteAuthor',
       defaultMessage: 'Mute user',


### PR DESCRIPTION
https://github.com/PrimalHQ/primal-web-app/issues/55

This change to a follow and unfollow button for a user through the note context and corrects a small spelling error.

