### PR TITLE
Render Embedded Zap Amount

### DIFF
--- a/src/components/EmbeddedNote/EmbeddedNote.module.scss
+++ b/src/components/EmbeddedNote/EmbeddedNote.module.scss
@@ -1,3 +1,16 @@
+.embeddedZapInfo {
+  display: flex;
+}
+
+.embeddedZapIcon {
+  width: 18px;
+  height: 18px;
+  background-color: var(--active-zap);
+  -webkit-mask: url(../../assets/icons/feed_zap_fill_2.svg) no-repeat center 0 /
+    auto 100%;
+  mask: url(../../assets/icons/feed_zap_fill_2.svg) no-repeat center 0 / auto
+    100%;
+}
 
 .mentionedNote {
   border: none;
@@ -58,7 +71,7 @@
         }
       }
 
-      .time{
+      .time {
         margin: 0px 2px;
         min-width: 40px;
         font-size: 14px;
@@ -107,7 +120,6 @@
         text-overflow: ellipsis;
         white-space: nowrap;
         overflow: hidden;
-
       }
     }
   }
@@ -116,3 +128,4 @@
 .noteContent {
   overflow: hidden;
 }
+


### PR DESCRIPTION
Currently if someone embeds a zap kind 9735 in a note using the `nostr:nevent1...` encoding, a note embed card is rendered but there is no information about the zap.

This PR is a simple improvement that adds the zap amount by parsing it from the embedded `description` tag in the zap.

The sender pubkey is also available so the sender profile could be rendered as well - although I was unsure how to get the `PrimalUser` class from the sender pubkey.

### Before
<img width="597" alt="fountain-embedded-zap-current" src="https://github.com/PrimalHQ/primal-web-app/assets/7327257/4dbc8acb-9916-48cb-83b8-62d9c4e60c80">

### After
<img width="596" alt="primal-embedded-zap-with-amount" src="https://github.com/PrimalHQ/primal-web-app/assets/7327257/1f33d0e4-c781-4f44-bb95-850278027cce">
