### PR TITLE
Fix issue where left navigation wouldn't scroll when height > screen

### DIFF
--- a/src/components/Layout/Layout.module.scss
+++ b/src/components/Layout/Layout.module.scss
@@ -37,6 +37,8 @@
     grid-template-rows: var(--header-height) 1fr 82px;
     height: 100%;
     border-right: 1px solid var(--devider);
+    overflow-y: auto;
+    overflow-x: hidden;
   }
 
   .leftHeader {
@@ -86,6 +88,7 @@
 
 .centerContent {
   width: var(--center-col-w);
+
   .headerFloater {
     position: fixed;
     opacity: 0;
@@ -118,6 +121,7 @@
 
   &.messagesColumn {
     height: 85px;
+
     >div {
       height: 85px;
       border-left: none;
@@ -164,9 +168,11 @@
 
 .rightContent {
   margin-top: 92px;
+
   >div {
     margin-left: 24px;
   }
+
   &.exploreHeader {
     margin-top: 20px;
   }
@@ -181,8 +187,8 @@
   width: 0px;
   height: 0px;
   position: absolute;
-  top:0;
-  left:0;
+  top: 0;
+  left: 0;
 }
 
 @media only screen and (max-width: 1300px) {
@@ -221,6 +227,7 @@
 
   .rightColumn {
     width: 1px;
+
     >div {
       >div {
         display: none;
@@ -295,6 +302,7 @@
 
   .rightColumn {
     width: 1px;
+
     >div {
       >div {
         display: none;

--- a/src/components/NavMenu/NavMenu.module.scss
+++ b/src/components/NavMenu/NavMenu.module.scss
@@ -1,3 +1,7 @@
+.navMenu {
+  padding: 0 0 12px;
+}
+
 .sideNav {
   display: flex;
   flex-direction: column;
@@ -13,7 +17,7 @@
 
   >button {
     margin: 0;
-    width: 100% ;
+    width: 100%;
   }
 
   .message {
@@ -53,7 +57,7 @@
     width: 100%;
     height: 48px;
 
-    > button {
+    >button {
       margin-bottom: 0px;
     }
   }
@@ -63,7 +67,8 @@
     bottom: 56px;
     left: calc(100vw - 48px);
 
-    .message, .action {
+    .message,
+    .action {
       display: none;
     }
   }
@@ -78,5 +83,5 @@
 
   background-color: var(--text-primary-button);
   -webkit-mask: url(../../assets/icons/post.svg) no-repeat 0 0 / 18px 18px;
-  mask: url(../../assets/icons/post.svg) no-repeat  0 0 / 18px 18px;
+  mask: url(../../assets/icons/post.svg) no-repeat 0 0 / 18px 18px;
 }


### PR DESCRIPTION
This PR fixes the issue #91 where the left navigation would not scroll vertically when being longer than the height of the screen in the browser.

Currently navigation is hidden and can't be accessed

![before](https://github.com/user-attachments/assets/753c24d8-e85d-47d0-bb5a-c6bbad3f105c)

With the fix, left navigation can be scrolled and accessed even if screen height small.

![after](https://github.com/user-attachments/assets/a5191209-9a18-415a-b8fa-5d7400baca98)
