### PR TITLE
Simple overlay to block clicks outside new note popup

### DIFF
--- a/src/components/Layout/Layout.module.scss
+++ b/src/components/Layout/Layout.module.scss
@@ -86,6 +86,7 @@
 
 .centerContent {
   width: var(--center-col-w);
+
   .headerFloater {
     position: fixed;
     opacity: 0;
@@ -97,6 +98,16 @@
       opacity: 1;
       transition: opacity 0.5s ease;
       pointer-events: all;
+    }
+
+    &.animatedShow::before {
+      content: "";
+      position: fixed;
+      left: 0;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      background-color: rgba(0, 0, 0, 0.3);
     }
   }
 }
@@ -118,6 +129,7 @@
 
   &.messagesColumn {
     height: 85px;
+
     >div {
       height: 85px;
       border-left: none;
@@ -164,9 +176,11 @@
 
 .rightContent {
   margin-top: 92px;
+
   >div {
     margin-left: 24px;
   }
+
   &.exploreHeader {
     margin-top: 20px;
   }
@@ -181,8 +195,8 @@
   width: 0px;
   height: 0px;
   position: absolute;
-  top:0;
-  left:0;
+  top: 0;
+  left: 0;
 }
 
 @media only screen and (max-width: 1300px) {
@@ -221,6 +235,7 @@
 
   .rightColumn {
     width: 1px;
+
     >div {
       >div {
         display: none;
@@ -295,6 +310,7 @@
 
   .rightColumn {
     width: 1px;
+
     >div {
       >div {
         display: none;


### PR DESCRIPTION
This PR addresses issue #50. I added an overlay preventing the user from clicking outside the "New Note" popup. 

I set the opacity to 0.3, but this could easily be changed to be transparent.

**Before**
![before](https://github.com/user-attachments/assets/97e18683-0615-4989-8404-ebdba0f56ffb)

**After**
![after](https://github.com/user-attachments/assets/e51d1e17-8fca-438d-bd36-c6bd823f5a5f)
