### PR TITLE
Corrected description to "no media" when user has no media in profile

### DIFF
--- a/src/components/ProfileTabs/ProfileTabs.tsx
+++ b/src/components/ProfileTabs/ProfileTabs.tsx
@@ -601,7 +601,7 @@ const ProfileTabs: Component<{
                     <Show when={profile && profile.gallery.length === 0 && !profile.isFetchingGallery}>
                       <div class={styles.mutedProfile}>
                         {intl.formatMessage(
-                          t.noReplies,
+                          t.noMedia,
                           { name: profile?.userProfile ? userName(profile?.userProfile) : props.profileKey },
                         )}
                       </div>

--- a/src/translations.ts
+++ b/src/translations.ts
@@ -1270,6 +1270,11 @@ export const profile = {
     defaultMessage: '{name} hasn\'t posted any replies',
     description: 'Label indicating that the profile has no replies',
   },
+  noMedia: {
+      id: 'profile.noMedia',
+      defaultMessage: '{name} hasn\'t posted any media',
+      description: 'Label indicating that the profile has no media',
+    },
   noFollowers: {
     id: 'profile.noFollowers',
     defaultMessage: '{name} has no followers',


### PR DESCRIPTION
Currently the info says incorrectly "user has no replies" when the user has no media.