### PR TITLE
Fix extra new lines for notes

### DIFF
--- a/src/components/NewNote/EditBox/EditBox.tsx
+++ b/src/components/NewNote/EditBox/EditBox.tsx
@@ -710,7 +710,7 @@ const EditBox: Component<{
       return;
     }
 
-    const value = message();
+    const value = message().trimEnd();
 
     if (value.trim() === '') {
       return;


### PR DESCRIPTION
Use `trimEnd()` to remove new lines from the note.

Issue: [issues/114](https://github.com/PrimalHQ/primal-web-app/issues/114)