### PR TITLE
Fix: add ability to close 'failed to zap' modal

### DIFF
--- a/src/components/Note/NoteFooter/ArticleFooter.tsx
+++ b/src/components/Note/NoteFooter/ArticleFooter.tsx
@@ -331,6 +331,8 @@ const ArticleFooter: Component<{
           title: "Failed to zap",
           description: lastZapError,
           confirmLabel: "ok",
+          abortLabel: "Cancel",
+          onAbort: app?.actions.closeConfirmModal,
         })
       }
 

--- a/src/components/Note/NoteFooter/NoteFooter.tsx
+++ b/src/components/Note/NoteFooter/NoteFooter.tsx
@@ -351,6 +351,8 @@ const NoteFooter: Component<{
           title: "Failed to zap",
           description: lastZapError,
           confirmLabel: "ok",
+          abortLabel: "Cancel",
+          onAbort: app?.actions.closeConfirmModal,
         })
       }
 


### PR DESCRIPTION
resolves #117 