### PR TITLE
Fix padding for markdown inline code blocks

### DIFF
--- a/src/components/PrimalMarkdown/PrimalMarkdown.module.scss
+++ b/src/components/PrimalMarkdown/PrimalMarkdown.module.scss
@@ -236,8 +236,13 @@
       font-style: normal;
       font-weight: 400;
       line-height: 28px;
-      border-radius: 12px;
+      border-radius: 8px;
+      padding: 0px 4px;
+    }
+
+    pre code {
       padding: 20px;
+      border-radius: 12px;
     }
 
     ins {


### PR DESCRIPTION
Fix for https://github.com/PrimalHQ/primal-web-app/issues/135

I first noticed this issue while reading Semisol's [recent article](https://primal.net/a/naddr1qvzqqqr4gupzq5455pmtewaacws6a73hxkqkea6fjwcm3keq9vqu3q7930nl4k9aqqgxummnw3ez6ct594ekxctvv5knzfhxgfl).

Fixing by only setting 20px padding on code blocks (via css selector `pre code`). Added reduced padding and border radius for inline code.

Created my own long form note to validate: https://primal.net/anders/Testing-markdown-rendering-5m42ur

Before:
<img width="678" alt="Screenshot 2025-05-03 at 1 59 06 PM" src="https://github.com/user-attachments/assets/cda85885-8bb5-4b51-838a-b6a570190d03" />


After:
<img width="637" alt="Screenshot 2025-05-03 at 1 58 40 PM" src="https://github.com/user-attachments/assets/821fb455-04aa-4c81-b501-23e2afcae7b0" />


