### PR TITLE
fix: pressing esc should close confirmation modal

### DIFF
--- a/src/components/NewNote/EditBox/EditBox.tsx
+++ b/src/components/NewNote/EditBox/EditBox.tsx
@@ -643,7 +643,7 @@ const EditBox: Component<{
   const onEscape = (e: KeyboardEvent) => {
     if (justClosedModal()) {
       setJustClosedModal(false);
-    return;
+      return;
     }
 
     if (isConfirmEditorClose()) return;

--- a/src/components/NewNote/EditBox/EditBox.tsx
+++ b/src/components/NewNote/EditBox/EditBox.tsx
@@ -115,6 +115,7 @@ const EditBox: Component<{
   const [referencedArticles, setReferencedArticles] = createStore<Record<string, FeedPage>>();
 
   const [isConfirmEditorClose, setConfirmEditorClose] = createSignal(false);
+  const [justClosedModal, setJustClosedModal] = createSignal(false);
 
   const [fileToUpload, setFileToUpload] = createSignal<File | undefined>();
 
@@ -640,6 +641,11 @@ const EditBox: Component<{
   });
 
   const onEscape = (e: KeyboardEvent) => {
+    if (justClosedModal()) {
+      setJustClosedModal(false);
+    return;
+    }
+
     if (isConfirmEditorClose()) return;
 
     e.stopPropagation();
@@ -1954,6 +1960,7 @@ const EditBox: Component<{
         }}
         onCancel={() => {
           setConfirmEditorClose(false);
+          setJustClosedModal(true);
           textArea?.focus();
         }}
       />


### PR DESCRIPTION
closes #151 

### Context

The issue occurs because the Escape key event bubbles from the modal's Dialog component to the parent `EditBox` component's `onEscape` handler, which then re-triggers the `closeEditor` function, reopening the confirm modal in an endless loop.

The fix involves adding a signal in `EditBox` to track when the modal was just closed via Escape, preventing the re-trigger in the `onEscape` handler. This ensures the modal closes cleanly without the continuous open/close cycle.