### PR TITLE
  Fix: Checkbox visibility issue in light themes

### DIFF
--- a/src/assets/icons/check-dark.svg
+++ b/src/assets/icons/check-dark.svg
@@ -1,0 +1,1 @@
+<svg width="12" height="10" viewBox="0 0 12 10" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0 5.76523L1.44516 4.23477L4 6.93908L10.5548 0L12 1.53046L4 10L0 5.76523Z" fill="white"/></svg>

--- a/src/assets/icons/check-light.svg
+++ b/src/assets/icons/check-light.svg
@@ -1,0 +1,1 @@
+<svg width="12" height="10" viewBox="0 0 12 10" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M0 5.76523L1.44516 4.23477L4 6.93908L10.5548 0L12 1.53046L4 10L0 5.76523Z" fill="black"/></svg>

--- a/src/components/Checkbox/Checkbox.module.scss
+++ b/src/components/Checkbox/Checkbox.module.scss
@@ -49,9 +49,9 @@
   width: 12px;
   height: 12px;
 
-  background-color: var(--text-primary);
-  -webkit-mask: url(../../assets/icons/check.svg) 0 / 100% no-repeat;
-  mask: url(../../assets/icons/check.svg) 0 / 100% no-repeat;
+  background-color: var(--checkbox-check-color);
+  -webkit-mask: var(--check-image) 0 / 100% no-repeat;
+  mask: var(--check-image) 0 / 100% no-repeat;
 }
 
 

--- a/src/palette.scss
+++ b/src/palette.scss
@@ -45,7 +45,8 @@
 
   --profile-indicator-border: var(--background-site);
 
-  --check-image: url('./assets/icons/check.svg');
+  --checkbox-check-color: #ffffff;
+  --check-image: url('./assets/icons/check-dark.svg');
   --logo: url('./assets/icons/logo_fire.svg');
   --logo-big: url('./assets/icons/logo_fire_big.svg');
   --icon-follows: url('./assets/icons/follows.svg');
@@ -123,7 +124,8 @@
 
   --profile-indicator-border: var(--background-site);
 
-  --check-image: url('./assets/icons/check.svg');
+  --checkbox-check-color: #ffffff;
+  --check-image: url('./assets/icons/check-dark.svg');
   --logo: url('./assets/icons/logo_ice.svg');
   --logo-big: url('./assets/icons/logo_ice_big.svg');
   --icon-follows: url('./assets/icons/follows.svg');
@@ -200,7 +202,8 @@
 
   --profile-indicator-border: var(--accent);
 
-  --check-image: url('./assets/icons/check.svg');
+  --checkbox-check-color: #000000;
+  --check-image: url('./assets/icons/check-light.svg');
   --logo: url('./assets/icons/logo_fire.svg');
   --logo-big: url('./assets/icons/logo_fire_big_l.svg');
   --icon-follows: url('./assets/icons/follows.svg');
@@ -278,7 +281,8 @@
 
   --profile-indicator-border: var(--accent);
 
-  --check-image: url('./assets/icons/check.svg');
+  --checkbox-check-color: #000000;
+  --check-image: url('./assets/icons/check-light.svg');
   --logo: url('./assets/icons/logo_ice.svg');
   --logo-big: url('./assets/icons/logo_ice_big_l.svg');
   --icon-follows: url('./assets/icons/follows.svg');


### PR DESCRIPTION
  ## Bug Description
  Checkboxes were invisible in light themes (Sunrise Wave and Ice Wave) in Settings sections like "Notifications"
  and "Content Moderation", while they remained visible in dark themes.

  ## Root Cause
  The checkbox component used a white SVG icon (`check.svg`) with CSS masks, which worked fine on dark backgrounds
  but was invisible on light backgrounds due to insufficient contrast.

  ## Solution
  Implemented theme-aware checkbox styling using CSS variables and theme-specific SVG assets:

  1. **Added theme-specific SVG icons:**
     - `check-dark.svg` - White fill for dark themes
     - `check-light.svg` - Black fill for light themes

  2. **Updated theme palette variables:**
     - Dark themes (sunset, midnight): `--checkbox-check-color: #ffffff` + `check-dark.svg`
     - Light themes (sunrise, ice): `--checkbox-check-color: #000000` + `check-light.svg`

  3. **Modified checkbox component styling:**
     - Uses `var(--checkbox-check-color)` for background color
     - Uses `var(--check-image)` for theme-appropriate SVG mask
     - Maintains existing CSS mask approach for clean rendering

  ## Files Changed
  - `src/assets/icons/check-dark.svg` (new)
  - `src/assets/icons/check-light.svg` (new)
  - `src/palette.scss` (added theme variables)
  - `src/components/Checkbox/Checkbox.module.scss` (updated styling)

  ## Result
  Checkboxes now display properly with appropriate contrast in all four themes:
  - Dark themes: White checkmarks
  - Light themes: Black checkmarks

  Fixes #136