### PR TITLE
Resolves z-index stacking context issue by using portal rendering

### DIFF
--- a/src/components/HomeSidebar/HomeSidebar.module.scss
+++ b/src/components/HomeSidebar/HomeSidebar.module.scss
@@ -5,7 +5,7 @@
   width: 100%;
   height: 44px;
   background-color: var(--background-site);
-  z-index: 5;
+  z-index: 50;
   padding-bottom: 22px;
   display:flex;
   flex-direction: row;

--- a/src/components/Layout/Layout.module.scss
+++ b/src/components/Layout/Layout.module.scss
@@ -119,6 +119,8 @@
 }
 
 .rightColumn {
+  position: relative;
+  z-index: 100;
   display: grid;
   width: var(--right-col-w);
   grid-template-rows: var(--header-height) 1fr;

--- a/src/components/SelectionBox/SelectionBox.module.scss
+++ b/src/components/SelectionBox/SelectionBox.module.scss
@@ -137,7 +137,7 @@
   margin-top: 7px;
   transform-origin: top left;
   animation: contentHide 150ms ease-in forwards;
-  z-index: var(--z-index-lifted);
+  z-index: 100;
 
   >ul {
     overflow-y: scroll;

--- a/src/components/SelectionBox/SelectionBox2.tsx
+++ b/src/components/SelectionBox/SelectionBox2.tsx
@@ -137,6 +137,10 @@ const SelectionBox2: Component<{
       defaultValue={defaultValue()}
       value={value()}
       onChange={onOptionSelect}
+      gutter={8}
+      sameWidth={false}
+      placement="bottom-start"
+      shift={-8}
     >
       <Select.Trigger class={props.big ? styles.triggerBig : styles.trigger}>
           <Select.Value<SelectionOption>>
@@ -148,17 +152,19 @@ const SelectionBox2: Component<{
             </Show>
           </Select.Icon>
       </Select.Trigger>
-      <Select.Content class={styles.selectionContent}>
-        <Show when={hasCaption()}>
-          <div class={styles.caption}>
-            <div class={styles.title}>
-              {props.caption && `${props.caption}:`}
+      <Select.Portal>
+        <Select.Content class={styles.selectionContent}>
+          <Show when={hasCaption()}>
+            <div class={styles.caption}>
+              <div class={styles.title}>
+                {props.caption && `${props.caption}:`}
+              </div>
+              {props.captionAction}
             </div>
-            {props.captionAction}
-          </div>
-        </Show>
-        <Select.Listbox class={`${styles.listbox} ${hasCaption() ? styles.withCaption : '' }`}/>
-      </Select.Content>
+          </Show>
+          <Select.Listbox class={`${styles.listbox} ${hasCaption() ? styles.withCaption : '' }`}/>
+        </Select.Content>
+      </Select.Portal>
     </Select>
   );
 }


### PR DESCRIPTION
## Summary
  Fixes a z-index bug where the "Trending 24h" dropdown menu in the main timeline would appear behind image galleries in posts.

  ## Changes
  - **SelectionBox2.tsx**: Wrapped `Select.Content` with `Select.Portal` to render dropdown outside normal DOM hierarchy
  - **SelectionBox2.tsx**: Added positioning props (`gutter={8}`, `placement="bottom-start"`, `shift={-8}`, `sameWidth={false}`) to maintain original dropdown alignment
  - **SelectionBox.module.scss**: Increased dropdown z-index from `var(--z-index-lifted)` (10) to 100
  - **HomeSidebar.module.scss**: Increased sidebar heading z-index from 5 to 50
  - **Layout.module.scss**: Added `position: relative; z-index: 100` to `.rightColumn`

  ## Root Cause
  The `.centerColumn` element had `position: relative`, creating an isolated stacking context. This prevented the dropdown (rendered as a child of `.rightColumn`) from appearing above content in the center column, regardless of z-index values.

  ## Solution
  Using `Select.Portal` renders the dropdown at the document body level, completely escaping all parent stacking contexts. This ensures the dropdown appears above all page content while maintaining proper positioning relative to its trigger.

  ## Test Plan
  - [x] Verify dropdown appears above image galleries in posts
  - [x] Verify dropdown positioning matches original alignment
  - [x] Tested with top 24-hour trending post ID:
  nevent1qvzqqqqqqypzqeqq2md08cn2vft4vd3yk49qkw6hn8t59zc7yp770mxwln3j4ak2qqsvv968dyyrl4utjc0g9zptywvzqk3wj7glnemexsr4lqwsa59xzysxj23l5
  
  ## Screenshots

Before:
<img width="995" height="829" alt="image" src="https://github.com/user-attachments/assets/c44f9ade-2496-4102-9712-77a7ca6f84a5" />

After:
<img width="995" height="829" alt="image" src="https://github.com/user-attachments/assets/9039fdfc-2f44-482c-a8c5-562c4ab20b94" />

Dev note: This fix was developed with Claude Sonnet 4.5.