### PR TITLE
Show if a user has muted you

### DIFF
--- a/src/pages/Profile.module.scss
+++ b/src/pages/Profile.module.scss
@@ -647,6 +647,11 @@
   /* margin-left: 8px; */
 }
 
+.mutedBadge {
+  width: auto;
+  padding-inline: 6px;
+}
+
 .phoneAvatar {
   display: none;
   position: relative;

--- a/src/translations.ts
+++ b/src/translations.ts
@@ -1406,6 +1406,11 @@ export const profile = {
     defaultMessage: 'Follows you',
     description: 'Label indicating that a profile is following your profile',
   },
+  mutedYou: {
+    id: 'profile.mutedYou',
+    defaultMessage: 'Muted you',
+    description: 'Label indicating that a profile has muted your profile',
+  },
   jointDate: {
     id: 'profile.joinDate',
     defaultMessage: 'Joined Nostr on {date}',


### PR DESCRIPTION
fixed #157 

** Context **

Added a Badge to the page of the user who has muted the currently logged in account

** Visual **

<img width="1440" height="778" alt="Снимок экрана 2025-12-17 в 14 26 22" src="https://github.com/user-attachments/assets/d2038603-9214-4563-bdb1-040d590ac2a8" />
