### PR TITLE
fix: use correct query param separator in LNURL callback URLs

### DIFF
--- a/src/lib/zap.ts
+++ b/src/lib/zap.ts
@@ -12,6 +12,11 @@ import { Event } from "nostr-tools";
 
 export let lastZapError: string = "";
 
+const buildCallbackUrl = (callback: string, amount: number, nostrEvent: string): string => {
+  const separator = callback.includes('?') ? '&' : '?';
+  return `${callback}${separator}amount=${amount}&nostr=${nostrEvent}`;
+};
+
 export const zapOverNWC = async (pubkey: string, nwcEnc: string, invoice: string) => {
 
   try {
@@ -88,7 +93,7 @@ export const zapNote = async (
 
     const event = encodeURIComponent(JSON.stringify(signedEvent));
 
-    const r2 = await (await fetch(`${callback}?amount=${sats}&nostr=${event}`)).json();
+    const r2 = await (await fetch(buildCallbackUrl(callback, sats, event))).json();
     const pr = r2.pr;
 
     if (nwc && nwc[1] && nwc[1].length > 0) {
@@ -150,7 +155,7 @@ export const zapArticle = async (
 
     const event = encodeURIComponent(JSON.stringify(signedEvent));
 
-    const r2 = await (await fetch(`${callback}?amount=${sats}&nostr=${event}`)).json();
+    const r2 = await (await fetch(buildCallbackUrl(callback, sats, event))).json();
     const pr = r2.pr;
 
     if (nwc && nwc[1] && nwc[1].length > 0) {
@@ -204,7 +209,7 @@ export const zapProfile = async (
 
     const event = encodeURIComponent(JSON.stringify(signedEvent));
 
-    const r2 = await (await fetch(`${callback}?amount=${sats}&nostr=${event}`)).json();
+    const r2 = await (await fetch(buildCallbackUrl(callback, sats, event))).json();
     const pr = r2.pr;
 
     if (nwc && nwc[1] && nwc[1].length > 0) {
@@ -276,7 +281,7 @@ export const zapSubscription = async (
 
     const event = encodeURIComponent(JSON.stringify(signedEvent));
 
-    const r2 = await (await fetch(`${callback}?amount=${sats}&nostr=${event}`)).json();
+    const r2 = await (await fetch(buildCallbackUrl(callback, sats, event))).json();
     const pr = r2.pr;
 
     if (nwc && nwc[1] && nwc[1].length > 0) {
@@ -339,7 +344,7 @@ export const zapDVM = async (
 
     const event = encodeURIComponent(JSON.stringify(signedEvent));
 
-    const r2 = await (await fetch(`${callback}?amount=${sats}&nostr=${event}`)).json();
+    const r2 = await (await fetch(buildCallbackUrl(callback, sats, event))).json();
     const pr = r2.pr;
 
     if (nwc && nwc[1] && nwc[1].length > 0) {
@@ -402,7 +407,7 @@ export const zapStream = async (
 
     const event = encodeURIComponent(JSON.stringify(signedEvent));
 
-    const r2 = await (await fetch(`${callback}?amount=${sats}&nostr=${event}`)).json();
+    const r2 = await (await fetch(buildCallbackUrl(callback, sats, event))).json();
     const pr = r2.pr;
 
     if (nwc && nwc[1] && nwc[1].length > 0) {


### PR DESCRIPTION
## Summary

- Fixes malformed LNURL callback URLs when the callback already contains query parameters
- Adds `buildCallbackUrl()` helper that checks for existing `?` and uses `&` accordingly
- Applies fix to all 6 zap functions: `zapNote`, `zapArticle`, `zapProfile`, `zapSubscription`, `zapDVM`, `zapStream`

## Problem

When LNURL callback URLs already contain query parameters (e.g., `?webhook_data=...`), Primal was appending `?amount=...` instead of `&amount=...`. This resulted in:

```
# Broken (what Primal was sending):
https://example.com/callback?webhook_data=foo?amount=10000&nostr=...

# Correct (what it should send):
https://example.com/callback?webhook_data=foo&amount=10000&nostr=...
```

Servers parsing query parameters didn't see `amount` at the top level, causing LNURL-pay/zap flows to fail with validation errors like:
```json
{"detail":"[{'loc': ('query', 'amount'), 'msg': 'field required', 'type': 'value_error.missing'}]"}
```

## Test plan

- [ ] Test zapping a user whose LNURL callback has no query params (should still work)
- [ ] Test zapping a user whose LNURL callback has existing query params like `?webhook_data=...` (should now work)

Fixes #159
