### PR TITLE
Fix livestream header border alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@
     <img src="public/public/primal-web-banner.jpg" alt="iPhone Screenshot">
 </div>
 
+Interface update: Livestream header borders align between the stream and live chat panels. Current version: 2.6.11.
+
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ### Built With

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "primal-web-app",
-  "version": "2.6.10",
+  "version": "2.6.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "primal-web-app",
-      "version": "2.6.10",
+      "version": "2.6.11",
       "license": "MIT",
       "dependencies": {
         "@cashu/cashu-ts": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "primal-web-app",
-  "version": "2.6.10",
+  "version": "2.6.11",
   "description": "",
   "scripts": {
     "start": "vite",

--- a/src/pages/StreamPage.module.scss
+++ b/src/pages/StreamPage.module.scss
@@ -369,6 +369,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  min-height: 71px;
   padding: 15px 16px;
   border-bottom: 1px solid var(--subtile-devider);
 


### PR DESCRIPTION
## Summary
- align live chat header height with stream header to fix border intersection in livestream page
- bump version to 2.6.11 and note the interface update in README

## Reproduction
1. Open a livestream page with live chat visible.
2. Observe the top-right corner where stream header and chat header borders meet.
3. Borders are misaligned by a few pixels.

## Fix
- set `.chatHeader` min-height to 71px to match `.streamingHeader`

## Testing
- npm run build (main)
- npm run build (fix/livestream-border-alignment)

Co-Authored-By: Warp <agent@warp.dev>
