### PR TITLE
Pause offscreen feed videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@
     <img src="public/public/primal-web-banner.jpg" alt="iPhone Screenshot">
 </div>
 
+Interface update: Offscreen feed videos now pause instead of continuing playback. Current version: 2.6.11.
+
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ### Built With

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "primal-web-app",
-  "version": "2.6.10",
+  "version": "2.6.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "primal-web-app",
-      "version": "2.6.10",
+      "version": "2.6.11",
       "license": "MIT",
       "dependencies": {
         "@cashu/cashu-ts": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "primal-web-app",
-  "version": "2.6.10",
+  "version": "2.6.11",
   "description": "",
   "scripts": {
     "start": "vite",

--- a/src/components/ParsedNote/NoteVideo.tsx
+++ b/src/components/ParsedNote/NoteVideo.tsx
@@ -18,7 +18,7 @@ const NoteVideo: Component<{
   const app =useAppContext();
   const media = useMediaContext();
 
-  let videoEl: HTMLVideoElement | undefined;
+  let videoEl: HTMLMediaElement | undefined;
 
   let mediaController: HTMLElement | undefined;
   let hlsVideo: HTMLMediaElement | undefined;
@@ -47,7 +47,8 @@ const NoteVideo: Component<{
 
   const observer = new IntersectionObserver(entries => {
     entries.forEach((entry) => {
-      const video = entry.target as HTMLVideoElement;
+      const video = videoEl;
+      if (!video) return;
 
       if (entry.isIntersecting && video.paused) {
         video.muted = true;
@@ -65,9 +66,7 @@ const NoteVideo: Component<{
       }
       else {
         video.muted = true;
-        if (video.pause) {
-          video.pause();
-        }
+        video.pause();
       }
     });
   });
@@ -129,6 +128,7 @@ const NoteVideo: Component<{
   })
 
   onCleanup(() => {
+    videoEl?.pause();
     videoEl?.removeEventListener('click', onVideoClick);
 
     playButton?.removeEventListener('click', onPlayClick);


### PR DESCRIPTION
## Summary
- pause note videos when their container leaves the viewport
- bump version to 2.6.11 and document the behavior change in README

## Reproduction
1. Scroll the home feed until you see a video.
2. Click unmute and watch briefly.
3. Keep scrolling so the video leaves the screen.
4. The old video can resume playing while you are viewing other content.

## Fix
- use the actual media element for intersection handling and pause it when it leaves view
- ensure media is paused during cleanup

## Testing
- npm run build (main)
- npm run build (fix/pause-offscreen-video)

Co-Authored-By: Warp <agent@warp.dev>
