### PR TITLE
Add Web of Trust integration with nostr-wot-sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 .DS_Store
+.idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "media-chrome": "4.12.0",
         "medium-zoom": "1.0.8",
         "nostr-tools": "2.17.0",
-        "nostr-wot-sdk": "file:../nostr-wot-sdk",
+        "nostr-wot-sdk": "0.6.2",
         "pako": "2.1.0",
         "photoswipe": "5.4.3",
         "photoswipe-dynamic-caption-plugin": "1.2.7",
@@ -96,11 +96,12 @@
       }
     },
     "../nostr-wot-sdk": {
-      "version": "0.6.0",
+      "version": "0.6.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.10.0",
         "@types/react": "^18.2.0",
+        "esbuild-plugin-solid": "^0.6.0",
         "eslint": "^9.39.2",
         "solid-js": "^1.9.0",
         "tsup": "^8.0.1",
@@ -172,7 +173,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -2434,7 +2434,6 @@
       "resolved": "https://registry.npmjs.org/@milkdown/core/-/core-7.3.6.tgz",
       "integrity": "sha512-7jk1x0xNNr53FxZowxWNpIvD6yl8LlHP/8X9DyWuvKQl+H1oSpVrkcOv1CO3QEjCrSiGGStsoS4feCMhtCKODg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@milkdown/exception": "7.3.6",
         "remark-parse": "^11.0.0",
@@ -2453,7 +2452,6 @@
       "resolved": "https://registry.npmjs.org/@milkdown/ctx/-/ctx-7.3.6.tgz",
       "integrity": "sha512-ivVX5XIpT1/b4b5JC+ffpcxsrB+R0cNodry+AL63V2tvvTmG7IvKkCf8CHI6gnN17C3soHi8/auzYRYJBXzTAQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@milkdown/exception": "7.3.6",
         "tslib": "^2.5.0"
@@ -2547,7 +2545,6 @@
       "resolved": "https://registry.npmjs.org/@milkdown/preset-commonmark/-/preset-commonmark-7.3.6.tgz",
       "integrity": "sha512-AUhrcyPMPXWnHJLIth/cK4IHTshlJgIw2RavFOmE2IyTxjgN4JCLg8MSla5wqwNUcdDMxKH0VmVyNImwt+c4Mg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@milkdown/exception": "7.3.6",
         "@milkdown/utils": "7.3.6",
@@ -2587,7 +2584,6 @@
       "resolved": "https://registry.npmjs.org/@milkdown/prose/-/prose-7.3.6.tgz",
       "integrity": "sha512-uBPgqghlDLxlfFPPVpPslM0N1h/6RFol2NTug65LK00bqvnNz8AUB712LMORb+KC7SGPcfUSu3z54Wxx2a27fg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@milkdown/exception": "7.3.6",
         "prosemirror-changeset": "^2.2.1",
@@ -2626,7 +2622,6 @@
       "resolved": "https://registry.npmjs.org/@milkdown/transformer/-/transformer-7.3.6.tgz",
       "integrity": "sha512-uE3sRoufBRHyqULJg93g7eTcgmA6hJVX/hiy+p+whle2EB6q3nNJeHoZZrNR8A32o3i8IBvmEIvvguxUtK9RyQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@milkdown/exception": "7.3.6",
         "remark": "^15.0.1",
@@ -3120,7 +3115,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.26.1.tgz",
       "integrity": "sha512-fymyd/XZvYiHjBoLt1gxs024xP/LY26d43R1vluYq7AHBL/7DE3ywzy+1GEsGyAv5Je2L0KBhNIR/izbq3Kaqg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3514,7 +3508,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.26.1.tgz",
       "integrity": "sha512-8aF+mY/vSHbGFqyG663ds84b+vca5Lge3tHdTMTKazxCnhXR9dn2oQJMnZ78YZvdRbkPkMJJHti9h3K7u2UQvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -3594,7 +3587,6 @@
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -3857,7 +3849,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4200,7 +4191,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -8178,7 +8168,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.3.tgz",
       "integrity": "sha512-dY2HdaNXlARknJbrManZ1WyUtos+AP97AmvqdOQtWtrrC5g4mohVX5DTi9rXNFSk09eczLq9GuNTtq3EfMeMGA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -8208,7 +8197,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
       "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -8269,7 +8257,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.0.tgz",
       "integrity": "sha512-FatMIIl0vRHMcNc3sPy3cMw5MMyWuO1nWQxqvYpJvXAruucGvmQ2tyyjT2/Lbok77T9a/qZqBVCq4sj43V2ihw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -8754,7 +8741,6 @@
       "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -8853,7 +8839,6 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.67.0.tgz",
       "integrity": "sha512-SVrO9ZeX/QQyEGtuZYCVxoeAL5vGlYjJ9p4i4HFuekWl8y/LtJ7tJc10Z+ck1c8xOuoBm2MYzcLfTAffD0pl/A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -8891,7 +8876,6 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.3.2.tgz",
       "integrity": "sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9057,7 +9041,6 @@
       "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.9.tgz",
       "integrity": "sha512-A0ZBPJQldAeGCTW0YRYJmt7RCeh5rbFfPZ2aOttgYnctHE7HgKeHCBB/PVc2P7eOfmNXqMFFFoYYdm3S4dcbkA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.1.0",
         "seroval": "~1.3.0",
@@ -9444,7 +9427,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9674,7 +9656,6 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9980,7 +9961,6 @@
       "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.23.4.tgz",
       "integrity": "sha512-qI0VTlYmKzEqRsz1Nppdfcaww4RSxZAq77z2oNSl3cNg2h6do5C8Ffl0KqWQ1OpD8desWXsCrde7tKJ9gGTEyQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@videojs/http-streaming": "^3.17.2",
@@ -10043,7 +10023,6 @@
       "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",
@@ -10491,7 +10470,6 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "media-chrome": "4.12.0",
         "medium-zoom": "1.0.8",
         "nostr-tools": "2.17.0",
+        "nostr-wot-sdk": "file:../nostr-wot-sdk",
         "pako": "2.1.0",
         "photoswipe": "5.4.3",
         "photoswipe-dynamic-caption-plugin": "1.2.7",
@@ -92,6 +93,34 @@
         "vite": "4.4.9",
         "vite-plugin-pwa": "1.0.1",
         "vite-plugin-solid": "2.7.0"
+      }
+    },
+    "../nostr-wot-sdk": {
+      "version": "0.6.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.10.0",
+        "@types/react": "^18.2.0",
+        "eslint": "^9.39.2",
+        "solid-js": "^1.9.0",
+        "tsup": "^8.0.1",
+        "typescript": "^5.3.0",
+        "vitest": "^4.0.18"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "solid-js": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        }
       }
     },
     "node_modules/@apideck/better-ajv-errors": {
@@ -143,6 +172,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -2404,6 +2434,7 @@
       "resolved": "https://registry.npmjs.org/@milkdown/core/-/core-7.3.6.tgz",
       "integrity": "sha512-7jk1x0xNNr53FxZowxWNpIvD6yl8LlHP/8X9DyWuvKQl+H1oSpVrkcOv1CO3QEjCrSiGGStsoS4feCMhtCKODg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@milkdown/exception": "7.3.6",
         "remark-parse": "^11.0.0",
@@ -2422,6 +2453,7 @@
       "resolved": "https://registry.npmjs.org/@milkdown/ctx/-/ctx-7.3.6.tgz",
       "integrity": "sha512-ivVX5XIpT1/b4b5JC+ffpcxsrB+R0cNodry+AL63V2tvvTmG7IvKkCf8CHI6gnN17C3soHi8/auzYRYJBXzTAQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@milkdown/exception": "7.3.6",
         "tslib": "^2.5.0"
@@ -2515,6 +2547,7 @@
       "resolved": "https://registry.npmjs.org/@milkdown/preset-commonmark/-/preset-commonmark-7.3.6.tgz",
       "integrity": "sha512-AUhrcyPMPXWnHJLIth/cK4IHTshlJgIw2RavFOmE2IyTxjgN4JCLg8MSla5wqwNUcdDMxKH0VmVyNImwt+c4Mg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@milkdown/exception": "7.3.6",
         "@milkdown/utils": "7.3.6",
@@ -2554,6 +2587,7 @@
       "resolved": "https://registry.npmjs.org/@milkdown/prose/-/prose-7.3.6.tgz",
       "integrity": "sha512-uBPgqghlDLxlfFPPVpPslM0N1h/6RFol2NTug65LK00bqvnNz8AUB712LMORb+KC7SGPcfUSu3z54Wxx2a27fg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@milkdown/exception": "7.3.6",
         "prosemirror-changeset": "^2.2.1",
@@ -2592,6 +2626,7 @@
       "resolved": "https://registry.npmjs.org/@milkdown/transformer/-/transformer-7.3.6.tgz",
       "integrity": "sha512-uE3sRoufBRHyqULJg93g7eTcgmA6hJVX/hiy+p+whle2EB6q3nNJeHoZZrNR8A32o3i8IBvmEIvvguxUtK9RyQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@milkdown/exception": "7.3.6",
         "remark": "^15.0.1",
@@ -3085,6 +3120,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.26.1.tgz",
       "integrity": "sha512-fymyd/XZvYiHjBoLt1gxs024xP/LY26d43R1vluYq7AHBL/7DE3ywzy+1GEsGyAv5Je2L0KBhNIR/izbq3Kaqg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3478,6 +3514,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.26.1.tgz",
       "integrity": "sha512-8aF+mY/vSHbGFqyG663ds84b+vca5Lge3tHdTMTKazxCnhXR9dn2oQJMnZ78YZvdRbkPkMJJHti9h3K7u2UQvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -3557,6 +3594,7 @@
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -3819,6 +3857,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4161,6 +4200,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -7718,6 +7758,10 @@
       "integrity": "sha512-78BTryCLcLYv96ONU8Ws3Q1JzjlAt+43pWQhIl86xZmWeegYCNLPml7yQ+gG3vR6V5h4XGj+TxO+SS5dsThQIA==",
       "license": "MIT"
     },
+    "node_modules/nostr-wot-sdk": {
+      "resolved": "../nostr-wot-sdk",
+      "link": true
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -8134,6 +8178,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.3.tgz",
       "integrity": "sha512-dY2HdaNXlARknJbrManZ1WyUtos+AP97AmvqdOQtWtrrC5g4mohVX5DTi9rXNFSk09eczLq9GuNTtq3EfMeMGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -8163,6 +8208,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
       "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -8223,6 +8269,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.0.tgz",
       "integrity": "sha512-FatMIIl0vRHMcNc3sPy3cMw5MMyWuO1nWQxqvYpJvXAruucGvmQ2tyyjT2/Lbok77T9a/qZqBVCq4sj43V2ihw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -8707,6 +8754,7 @@
       "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -8805,6 +8853,7 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.67.0.tgz",
       "integrity": "sha512-SVrO9ZeX/QQyEGtuZYCVxoeAL5vGlYjJ9p4i4HFuekWl8y/LtJ7tJc10Z+ck1c8xOuoBm2MYzcLfTAffD0pl/A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -8842,6 +8891,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.3.2.tgz",
       "integrity": "sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -9007,6 +9057,7 @@
       "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.9.tgz",
       "integrity": "sha512-A0ZBPJQldAeGCTW0YRYJmt7RCeh5rbFfPZ2aOttgYnctHE7HgKeHCBB/PVc2P7eOfmNXqMFFFoYYdm3S4dcbkA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.1.0",
         "seroval": "~1.3.0",
@@ -9393,6 +9444,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9622,6 +9674,7 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9927,6 +9980,7 @@
       "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.23.4.tgz",
       "integrity": "sha512-qI0VTlYmKzEqRsz1Nppdfcaww4RSxZAq77z2oNSl3cNg2h6do5C8Ffl0KqWQ1OpD8desWXsCrde7tKJ9gGTEyQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@videojs/http-streaming": "^3.17.2",
@@ -9989,6 +10043,7 @@
       "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",
@@ -10436,6 +10491,7 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "media-chrome": "4.12.0",
     "medium-zoom": "1.0.8",
     "nostr-tools": "2.17.0",
+    "nostr-wot-sdk": "file:../nostr-wot-sdk",
     "pako": "2.1.0",
     "photoswipe": "5.4.3",
     "photoswipe-dynamic-caption-plugin": "1.2.7",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "media-chrome": "4.12.0",
     "medium-zoom": "1.0.8",
     "nostr-tools": "2.17.0",
-    "nostr-wot-sdk": "file:../nostr-wot-sdk",
+    "nostr-wot-sdk": "0.6.2",
     "pako": "2.1.0",
     "photoswipe": "5.4.3",
     "photoswipe-dynamic-caption-plugin": "1.2.7",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import 'hls-video-element';
 import 'videojs-video-element';
 import { accountStore, dequeEvent, enqueEvent, refreshQueue, startEventQueueMonitor, updateRelays } from './stores/accountStore';
 import { triggerImportEvents } from './lib/notes';
+import { WotProvider } from './contexts/WotContext';
 
 
 export const version = import.meta.env.PRIMAL_VERSION;
@@ -98,7 +99,9 @@ const App: Component = () => {
                             <HomeProvider>
                               <ExploreProvider>
                                 <ThreadProvider>
-                                  <AppRouter />
+                                  <WotProvider>
+                                    <AppRouter />
+                                  </WotProvider>
                                 </ThreadProvider>
                               </ExploreProvider>
                             </HomeProvider>

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -53,6 +53,7 @@ const Moderation = lazy(() => import('./pages/Settings/Moderation'));
 const NostrWalletConnect = lazy(() => import('./pages/Settings/NostrWalletConnect'));
 const Menu = lazy(() => import('./pages/Settings/Menu'));
 const BlossomSettings = lazy(() => import('./pages/Settings/Blossom'));
+const WebOfTrust = lazy(() => import('./pages/Settings/WebOfTrust'));
 // const Landing = lazy(() => import('./pages/Landing'));
 const AppDownloadQr = lazy(() => import('./pages/appDownloadQr'));
 const EventQueuePage = lazy(() => import('./pages/EventQueue'));
@@ -165,6 +166,7 @@ const AppRouter: Component = () => {
             <Route path="/nwc" component={NostrWalletConnect} />
             <Route path="/devtools" component={DevTools} />
             <Route path="/uploads" component={Blossom} />
+            <Route path="/wot" component={WebOfTrust} />
           </Route>
           <Route path="/bookmarks" component={Bookmarks} />
           <Route path="/settings/profile" component={EditProfile} />

--- a/src/components/ArticlePreview/ArticleCompactPreview.tsx
+++ b/src/components/ArticlePreview/ArticleCompactPreview.tsx
@@ -13,6 +13,7 @@ import { urlEncode, uuidv4 } from '../../utils';
 import Avatar from '../Avatar/Avatar';
 import { NoteReactionsState } from '../Note/Note';
 import VerificationCheck from '../VerificationCheck/VerificationCheck';
+import WotBadge from '../WotBadge/WotBadge';
 
 import defaultAvatarDark from '../../assets/images/reads_image_dark.png';
 import defaultAvatarLight from '../../assets/images/reads_image_light.png';
@@ -392,6 +393,9 @@ const ArticleCompactPreview: Component<{
             <Avatar user={props.article.user} size="micro"/>
             <div class={styles.userName}>{userName(props.article.user)}</div>
             <VerificationCheck user={props.article.user} />
+            <Show when={props.article.user?.pubkey}>
+              <WotBadge pubkey={props.article.user.pubkey} />
+            </Show>
             <div class={styles.nip05}>{props.article.user?.nip05 || ''}</div>
           </div>
           <div class={styles.time}>

--- a/src/components/ArticlePreview/ArticlePreview.module.scss
+++ b/src/components/ArticlePreview/ArticlePreview.module.scss
@@ -43,19 +43,17 @@
       gap: 4px;
 
       .userName {
+        display: flex;
+        align-items: center;
         color: var(--text-secondary);
         font-family: Nacelle;
         font-size: 14px;
         font-weight: 700;
         line-height: 14px;
-
         max-width: 218px;
-
         overflow: hidden;
-        display: -webkit-box;
-        -webkit-line-clamp: 1;
-        line-clamp: 1;
-        -webkit-box-orient: vertical;
+        white-space: nowrap;
+        text-overflow: ellipsis;
       }
 
       .nip05 {
@@ -809,19 +807,17 @@
       gap: 4px;
 
       .userName {
+        display: flex;
+        align-items: center;
         color: var(--text-secondary);
         font-family: Nacelle;
         font-size: 14px;
         font-weight: 700;
         line-height: 14px;
-
         max-width: 218px;
-
         overflow: hidden;
-        display: -webkit-box;
-        -webkit-line-clamp: 1;
-        line-clamp: 1;
-        -webkit-box-orient: vertical;
+        white-space: nowrap;
+        text-overflow: ellipsis;
       }
 
       .nip05 {

--- a/src/components/ArticlePreview/ArticlePreview.tsx
+++ b/src/components/ArticlePreview/ArticlePreview.tsx
@@ -16,6 +16,7 @@ import NoteContextTrigger from '../Note/NoteContextTrigger';
 import ArticleFooter from '../Note/NoteFooter/ArticleFooter';
 import NoteTopZapsCompact from '../Note/NoteTopZapsCompact';
 import VerificationCheck from '../VerificationCheck/VerificationCheck';
+import WotBadge from '../WotBadge/WotBadge';
 
 import defaultAvatarDark from '../../assets/images/reads_image_dark.png';
 import defaultAvatarLight from '../../assets/images/reads_image_light.png';
@@ -380,6 +381,9 @@ const ArticlePreview: Component<ArticleProps> = (props) => {
           <Avatar user={props.article.user} size="micro"/>
           <div class={styles.userName}>{userName(props.article.user)}</div>
           <VerificationCheck user={props.article.user} />
+          <Show when={props.article.user?.pubkey}>
+            <WotBadge pubkey={props.article.user.pubkey} />
+          </Show>
           <div class={styles.nip05}>{props.article.user?.nip05 || ''}</div>
         </div>
         <div class={styles.time}>

--- a/src/components/ArticlePreview/ArticleShort.tsx
+++ b/src/components/ArticlePreview/ArticleShort.tsx
@@ -9,6 +9,7 @@ import { userName } from '../../stores/profile';
 import { PrimalArticle } from '../../types/primal';
 import { urlEncode } from '../../utils';
 import Avatar from '../Avatar/Avatar';
+import WotBadge from '../WotBadge/WotBadge';
 
 import styles from './ArticlePreview.module.scss';
 import { nip19 } from 'nostr-tools';
@@ -92,7 +93,12 @@ const ArticleShort: Component<{
     >
       <div class={styles.header}>
         <Avatar user={props.article.user} size="micro"/>
-        <div class={styles.userName}>{userName(props.article.user)}</div>
+        <div class={styles.userName}>
+          {userName(props.article.user)}
+          <Show when={props.article.user?.pubkey}>
+            <WotBadge pubkey={props.article.user.pubkey} />
+          </Show>
+        </div>
         <div class={styles.time}>
           &bull;&nbsp;
           {date(props.article.published).label}

--- a/src/components/AuthorSubscribe/AuthorSubscribe.module.scss
+++ b/src/components/AuthorSubscribe/AuthorSubscribe.module.scss
@@ -21,6 +21,7 @@
 
       .userName {
         display: flex;
+        align-items: center;
         color: var(--text-primary);
         font-size: 18px;
         font-weight: 600;

--- a/src/components/AuthorSubscribe/AuthorSubscribe.tsx
+++ b/src/components/AuthorSubscribe/AuthorSubscribe.tsx
@@ -13,6 +13,7 @@ import { isDev } from '../../utils';
 import AuthorSubscribeSkeleton from '../Skeleton/AuthorSubscribeSkeleton';
 import { Tier, TierCost } from '../SubscribeToAuthorModal/SubscribeToAuthorModal';
 import VerificationCheck from '../VerificationCheck/VerificationCheck';
+import WotBadge from '../WotBadge/WotBadge';
 
 import styles from './AuthorSubscribe.module.scss';
 import { accountStore } from '../../stores/accountStore';
@@ -127,6 +128,9 @@ const AuthorSubscribe: Component<{
               <div class={styles.userName}>
                 {userName(props.author)}
                 <VerificationCheck user={props.author} />
+                <Show when={props.author?.pubkey}>
+                  <WotBadge pubkey={props.author!.pubkey} />
+                </Show>
               </div>
               <Show when={props.author?.nip05}>
                 <div class={styles.nip05}>

--- a/src/components/DirectMessages/DirectMessageContact.tsx
+++ b/src/components/DirectMessages/DirectMessageContact.tsx
@@ -6,6 +6,8 @@ import Avatar from '../Avatar/Avatar';
 import { nip05Verification, userName } from '../../stores/profile';
 import { DMContact } from '../../megaFeeds';
 import { date } from '../../lib/dates';
+import { useWotContext } from '../../contexts/WotContext';
+import WotBadge from '../WotBadge/WotBadge';
 
 const DirectMessageContact: Component<{
   id?: string,
@@ -13,6 +15,7 @@ const DirectMessageContact: Component<{
   isSelected?: boolean,
   onSelect?: (pubkey: string) => void,
 }> = (props) => {
+  const wot = useWotContext();
 
   const user = () => props.dmContact.user;
   const contactInfo = () => props.dmContact.dmInfo;
@@ -31,6 +34,9 @@ const DirectMessageContact: Component<{
         <div class={styles.firstLine}>
           <div class={styles.senderName}>
             {userName(user())}
+            <Show when={wot?.isConnected}>
+              <WotBadge pubkey={user().pubkey} variant="minimal" />
+            </Show>
           </div>
           <Show when={contactInfo().latest_at > 0}>
             <div class={styles.dotSeparator}></div>

--- a/src/components/LivePill/LivePill.module.scss
+++ b/src/components/LivePill/LivePill.module.scss
@@ -19,16 +19,15 @@
     gap: 2px;
 
     .authorName {
+      display: flex;
+      align-items: center;
       color: var(--text-primary);
       font-size: 14px;
       font-weight: 700;
       line-height: 16px;
-
       overflow: hidden;
-      display: -webkit-box;
-      -webkit-line-clamp: 1;
-      line-clamp: 1;
-      -webkit-box-orient: vertical;
+      white-space: nowrap;
+      text-overflow: ellipsis;
     }
 
     .ribbon {

--- a/src/components/LivePill/LivePill.tsx
+++ b/src/components/LivePill/LivePill.tsx
@@ -6,6 +6,7 @@ import { StreamingData } from "../../lib/streaming";
 import { useAppContext } from "../../contexts/AppContext";
 import { date } from "../../lib/dates";
 import { userName } from "../../stores/profile";
+import WotBadge from "../WotBadge/WotBadge";
 
 const LivePill: Component<{
   liveEvent: StreamingData,
@@ -26,7 +27,12 @@ const LivePill: Component<{
       <div class={styles.leftSide}>
         <Avatar user={props.liveAuthor} size="xxs" />
         <div class={styles.eventInfo}>
-          <div class={styles.authorName}>{props.liveEvent?.title || userName(props.liveAuthor)}</div>
+          <div class={styles.authorName}>
+            {props.liveEvent?.title || userName(props.liveAuthor)}
+            <Show when={props.liveAuthor?.pubkey}>
+              <WotBadge pubkey={props.liveAuthor!.pubkey} />
+            </Show>
+          </div>
           <div class={styles.ribbon}>
             <Show
               when={props.liveEvent.status === 'live'}

--- a/src/components/Note/NoteAuthorInfo.tsx
+++ b/src/components/Note/NoteAuthorInfo.tsx
@@ -8,6 +8,7 @@ import { authorName, nip05Verification } from '../../stores/profile';
 import { hookForDev } from '../../lib/devTools';
 import { date } from '../../lib/dates';
 import VerificationCheck from '../VerificationCheck/VerificationCheck';
+import WotBadge from '../WotBadge/WotBadge';
 
 const NoteAuthorInfo: Component<{
   author: PrimalUser,
@@ -28,6 +29,8 @@ const NoteAuthorInfo: Component<{
       <VerificationCheck user={props.author} fallback={
         <div class={styles.verificationFailed}></div>
       } />
+
+      <WotBadge pubkey={props.author.pubkey} />
 
       <Show
         when={props.author.nip05}

--- a/src/components/Note/NoteHeader/NoteHeader.tsx
+++ b/src/components/Note/NoteHeader/NoteHeader.tsx
@@ -1,4 +1,4 @@
-import { Component, createEffect, createSignal, Show } from 'solid-js';
+import { Component, createSignal, Show } from 'solid-js';
 import { MenuItem, NostrRelaySignedEvent, PrimalNote } from '../../../types/primal';
 
 import styles from './NoteHeader.module.scss';
@@ -16,6 +16,7 @@ import { hexToNpub } from '../../../lib/keys';
 import { hookForDev } from '../../../lib/devTools';
 import { useAppContext } from '../../../contexts/AppContext';
 import { accountStore, addToMuteList, removeFromMuteList } from '../../../stores/accountStore';
+import WotBadge from '../../WotBadge/WotBadge';
 
 const NoteHeader: Component<{
   note: PrimalNote,
@@ -226,6 +227,7 @@ const NoteHeader: Component<{
             <VerificationCheck
               user={props.note.user}
             />
+            <WotBadge pubkey={props.note.post.pubkey} />
           </div>
           <Show
             when={props.note.user?.nip05}

--- a/src/components/Notifications/NotificationItem.module.scss
+++ b/src/components/Notifications/NotificationItem.module.scss
@@ -96,6 +96,8 @@
 }
 
 .verification {
+  display: flex;
+  align-items: center;
   min-width: 4px;
 }
 

--- a/src/components/Notifications/NotificationItem.tsx
+++ b/src/components/Notifications/NotificationItem.tsx
@@ -66,6 +66,7 @@ import { truncateNumber } from '../../lib/notifications';
 import ArticlePreview from '../ArticlePreview/ArticlePreview';
 import { useSettingsContext } from '../../contexts/SettingsContext';
 import { StreamingData } from '../../lib/streaming';
+import WotBadge from '../WotBadge/WotBadge';
 
 const typeIcons: Record<string, string> = {
   [NotificationType.NEW_USER_FOLLOWED_YOU]: userFollow,
@@ -353,6 +354,9 @@ const NotificationItem: Component<NotificationItemProps> = (props) => {
               <span class={styles.firstUserName}>{firstUserName()}</span>
               <div class={styles.verification}>
                 <VerificationCheck user={sortedUsers()[0]} />
+                <Show when={sortedUsers()[0]?.pubkey}>
+                  <WotBadge pubkey={sortedUsers()[0].pubkey} />
+                </Show>
               </div>
             </div>
             <div class={styles.restUsers}>{typeDescription()}</div>

--- a/src/components/Notifications/NotificationItemOld.tsx
+++ b/src/components/Notifications/NotificationItemOld.tsx
@@ -61,6 +61,7 @@ import ArticlePreview from '../ArticlePreview/ArticlePreview';
 import ArticleCompactPreview from '../ArticlePreview/ArticleCompactPreview';
 import ArticleHighlight from '../ArticleHighlight/ArticleHighlight';
 import VerificationCheck from '../VerificationCheck/VerificationCheck';
+import WotBadge from '../WotBadge/WotBadge';
 import { date } from '../../lib/dates';
 import { useSettingsContext } from '../../contexts/SettingsContext';
 import { StreamingData } from '../../lib/streaming';
@@ -370,6 +371,9 @@ const NotificationItemOld: Component<NotificationItemProps> = (props) => {
               <span class={styles.firstUserName}>{userName(user())}</span>
               <div class={styles.verification}>
                 <VerificationCheck user={user()} />
+                <Show when={user()?.pubkey}>
+                  <WotBadge pubkey={user()!.pubkey} />
+                </Show>
               </div>
             </div>
             <div class={styles.restUsers}>{typeDescription()}</div>

--- a/src/components/PeopleList/MentionedPerson.tsx
+++ b/src/components/PeopleList/MentionedPerson.tsx
@@ -9,6 +9,8 @@ import FollowButton from '../FollowButton/FollowButton';
 
 import styles from './PeopleList.module.scss';
 import { accountStore } from '../../stores/accountStore';
+import { useWotContext } from '../../contexts/WotContext';
+import WotBadge from '../WotBadge/WotBadge';
 
 
 const MentionedPerson: Component<{
@@ -17,6 +19,7 @@ const MentionedPerson: Component<{
   noAbout?: boolean,
 }> = (props) => {
   const app = useAppContext();
+  const wot = useWotContext();
 
   return (
     <A href={app?.actions.profileLink(props.person?.npub) || ''} class={styles.mentionedPerson}>
@@ -28,6 +31,9 @@ const MentionedPerson: Component<{
         <div class={styles.content}>
           <div class={styles.name}>
             {authorName(props.person)}
+            <Show when={wot?.isConnected}>
+              <WotBadge pubkey={props.person?.pubkey} variant="minimal" />
+            </Show>
           </div>
           <div class={styles.verification} title={props.person?.nip05}>
             <Show when={props.person?.nip05}>

--- a/src/components/ProfileContact/ProfileContact.module.scss
+++ b/src/components/ProfileContact/ProfileContact.module.scss
@@ -27,6 +27,8 @@
         padding-left: 8px;
 
         .name {
+          display: flex;
+          align-items: center;
           color: var(--text-primary);
           font-size: 16px;
           font-weight: 700;

--- a/src/components/ProfileContact/ProfileContact.tsx
+++ b/src/components/ProfileContact/ProfileContact.tsx
@@ -14,6 +14,7 @@ import { A } from '@solidjs/router';
 import { humanizeNumber } from '../../lib/stats';
 import { useAppContext } from '../../contexts/AppContext';
 import { accountStore } from '../../stores/accountStore';
+import WotBadge from '../WotBadge/WotBadge';
 
 
 const ProfileContact: Component<{
@@ -34,7 +35,12 @@ const ProfileContact: Component<{
           <Avatar src={props.profile?.picture} size="sm" />
 
           <div class={styles.profileInfo}>
-            <div class={styles.name}>{userName(props.profile)}</div>
+            <div class={styles.name}>
+              {userName(props.profile)}
+              <Show when={props.profile?.pubkey}>
+                <WotBadge pubkey={props.profile!.pubkey} />
+              </Show>
+            </div>
             <div class={styles.nip05}>
               <Show when={props.profile?.nip05}>
                 <span

--- a/src/components/ProfileNoteZap/ProfileNoteZap.tsx
+++ b/src/components/ProfileNoteZap/ProfileNoteZap.tsx
@@ -12,6 +12,7 @@ import Avatar from "../Avatar/Avatar";
 import styles from  "./ProfileNoteZap.module.scss";
 import { isPhone } from "../../utils";
 import { nip19 } from "nostr-tools";
+import WotBadge from "../WotBadge/WotBadge";
 
 
 const ProfileNoteZap: Component<{
@@ -87,6 +88,9 @@ const ProfileNoteZap: Component<{
         <div class={styles.contentZapPhone} data-zap-id={props.zap.id}>
           <div class={styles.zapSender}>
             <Avatar size="xxs" user={props.zap.sender} />
+            <Show when={typeof props.zap.sender !== 'string' && props.zap.sender?.pubkey}>
+              <WotBadge pubkey={(props.zap.sender as PrimalUser).pubkey} />
+            </Show>
             <div class={styles.amount}>
               <div class={styles.zapIcon}></div>
               <div class={styles.number}>{props.zap.amount.toLocaleString()}</div>
@@ -114,7 +118,10 @@ const ProfileNoteZap: Component<{
           <div class={styles.zapInfo}>
             <A href={app?.actions.profileLink(userNpub(props.zap.sender)) || ''} class={styles.sender}>
               <Avatar size="vs2" user={props.zap.sender} />
-            </A >
+            </A>
+            <Show when={typeof props.zap.sender !== 'string' && props.zap.sender?.pubkey}>
+              <WotBadge pubkey={(props.zap.sender as PrimalUser).pubkey} />
+            </Show>
 
             <div class={styles.data}>
               <div class={styles.amount}>

--- a/src/components/SmallNote/SmallNote.module.scss
+++ b/src/components/SmallNote/SmallNote.module.scss
@@ -36,6 +36,8 @@
       align-items: center;
 
       .name {
+        display: flex;
+        align-items: center;
         color: var(--text-secondary-2);
         font-weight: 800;
         max-width: 216px;

--- a/src/components/SmallNote/SmallNote.tsx
+++ b/src/components/SmallNote/SmallNote.tsx
@@ -13,6 +13,7 @@ import { hookForDev } from '../../lib/devTools';
 import ParsedNote from '../ParsedNote/ParsedNote';
 import { useAppContext } from '../../contexts/AppContext';
 import { nip19 } from 'nostr-tools';
+import WotBadge from '../WotBadge/WotBadge';
 
 
 const SmallNote: Component<{ note: PrimalNote, children?: JSXElement, id?: string }> = (props) => {
@@ -97,6 +98,9 @@ const SmallNote: Component<{ note: PrimalNote, children?: JSXElement, id?: strin
         <div class={styles.header}>
           <div class={styles.name} title={nameOfAuthor()}>
             {nameOfAuthor()}
+            <Show when={props.note.user?.pubkey}>
+              <WotBadge pubkey={props.note.user.pubkey} />
+            </Show>
           </div>
           <div class={styles.time}>
             <Show

--- a/src/components/WotBadge/WotBadge.module.scss
+++ b/src/components/WotBadge/WotBadge.module.scss
@@ -1,0 +1,104 @@
+.wotBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+  margin-left: 4px;
+  margin-right: 6px;
+  cursor: default;
+  user-select: none;
+  color: white;
+}
+
+// Fallback for unknown/zero score
+.badgeUnknown {
+  background: linear-gradient(135deg, #d1d5db 0%, #9ca3af 100%);
+  color: #6b7280;
+}
+
+// Tooltip styles - rendered via Portal with position:fixed
+.tooltip {
+  position: fixed;
+  transform: translateX(-50%) translateY(-100%);
+  z-index: 9999;
+  pointer-events: none;
+  animation: tooltipFadeIn 0.15s ease;
+
+  // Arrow
+  &::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 6px solid transparent;
+    border-top-color: var(--background-card, #1a1a1a);
+  }
+}
+
+@keyframes tooltipFadeIn {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(calc(-100% + 4px));
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(-100%);
+  }
+}
+
+.tooltipContent {
+  background: var(--background-card, #1a1a1a);
+  border: 1px solid var(--subtile-devider, rgba(255, 255, 255, 0.1));
+  border-radius: var(--border-radius-small, 8px);
+  padding: 10px 12px;
+  min-width: 140px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.tooltipTitle {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-tertiary, #888);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--subtile-devider, rgba(255, 255, 255, 0.1));
+}
+
+.tooltipStats {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.tooltipRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.tooltipLabel {
+  font-size: 12px;
+  color: var(--text-secondary, #aaa);
+}
+
+.tooltipValue {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary, #fff);
+}
+
+.tooltipEmpty {
+  font-size: 12px;
+  color: var(--text-secondary, #aaa);
+  text-align: center;
+}

--- a/src/components/WotBadge/WotBadge.tsx
+++ b/src/components/WotBadge/WotBadge.tsx
@@ -1,0 +1,207 @@
+import { Component, Show, createMemo, createSignal, onCleanup } from "solid-js";
+import { Portal } from "solid-js/web";
+import { useCachedWoT, useExtension, getMyPubkey } from "../../contexts/WotContext";
+import styles from "./WotBadge.module.scss";
+
+// Color stops for the gradient (score -> color)
+// 0: gray, 50: orange, 65: yellow, 70: green, 100: light blue
+const colorStops = [
+  { score: 0, color: { r: 107, g: 114, b: 128 } },   // Gray #6b7280
+  { score: 50, color: { r: 245, g: 158, b: 11 } },   // Orange #f59e0b
+  { score: 65, color: { r: 234, g: 179, b: 8 } },    // Yellow #eab308
+  { score: 70, color: { r: 34, g: 197, b: 94 } },    // Green #22c55e
+  { score: 100, color: { r: 56, g: 189, b: 248 } },  // Light blue #38bdf8
+];
+
+function interpolateColor(score: number): string {
+  const s = Math.max(0, Math.min(100, score));
+
+  let lowerStop = colorStops[0];
+  let upperStop = colorStops[colorStops.length - 1];
+
+  for (let i = 0; i < colorStops.length - 1; i++) {
+    if (s >= colorStops[i].score && s <= colorStops[i + 1].score) {
+      lowerStop = colorStops[i];
+      upperStop = colorStops[i + 1];
+      break;
+    }
+  }
+
+  const range = upperStop.score - lowerStop.score;
+  const factor = range === 0 ? 0 : (s - lowerStop.score) / range;
+
+  const r = Math.round(lowerStop.color.r + (upperStop.color.r - lowerStop.color.r) * factor);
+  const g = Math.round(lowerStop.color.g + (upperStop.color.g - lowerStop.color.g) * factor);
+  const b = Math.round(lowerStop.color.b + (upperStop.color.b - lowerStop.color.b) * factor);
+
+  return `rgb(${r}, ${g}, ${b})`;
+}
+
+function getDarkerColor(score: number): string {
+  const s = Math.max(0, Math.min(100, score));
+
+  let lowerStop = colorStops[0];
+  let upperStop = colorStops[colorStops.length - 1];
+
+  for (let i = 0; i < colorStops.length - 1; i++) {
+    if (s >= colorStops[i].score && s <= colorStops[i + 1].score) {
+      lowerStop = colorStops[i];
+      upperStop = colorStops[i + 1];
+      break;
+    }
+  }
+
+  const range = upperStop.score - lowerStop.score;
+  const factor = range === 0 ? 0 : (s - lowerStop.score) / range;
+
+  const darken = 0.85;
+  const r = Math.round((lowerStop.color.r + (upperStop.color.r - lowerStop.color.r) * factor) * darken);
+  const g = Math.round((lowerStop.color.g + (upperStop.color.g - lowerStop.color.g) * factor) * darken);
+  const b = Math.round((lowerStop.color.b + (upperStop.color.b - lowerStop.color.b) * factor) * darken);
+
+  return `rgb(${r}, ${g}, ${b})`;
+}
+
+const WotBadge: Component<{
+  pubkey: string;
+}> = (props) => {
+  const extension = useExtension();
+  const { data, loading } = useCachedWoT(() => props.pubkey);
+
+  let badgeRef: HTMLSpanElement | undefined;
+  const [showTooltip, setShowTooltip] = createSignal(false);
+  const [tooltipPos, setTooltipPos] = createSignal({ top: 0, left: 0 });
+
+  const isCurrentUser = createMemo(() => {
+    const myPubkey = getMyPubkey();
+    return myPubkey && props.pubkey === myPubkey;
+  });
+
+  const score = () => {
+    const d = data();
+    if (!d || d.score <= 0) return 0;
+    return Math.round(d.score * 100);
+  };
+
+  const badgeStyle = () => {
+    const s = score();
+    if (s <= 0) return {};
+
+    const mainColor = interpolateColor(s);
+    const darkColor = getDarkerColor(s);
+
+    return {
+      background: `linear-gradient(135deg, ${mainColor} 0%, ${darkColor} 100%)`,
+      'box-shadow': `0 1px 2px ${mainColor}4D`,
+    };
+  };
+
+  const getDisplayText = () => {
+    const s = score();
+    if (s <= 0) return '?';
+    return s.toString();
+  };
+
+  const tooltipData = () => {
+    const d = data();
+    if (!d) return null;
+
+    return {
+      score: d.score > 0 ? Math.round(d.score * 100) : null,
+      distance: d.distance,
+      paths: d.paths,
+      commonFollows: d.commonFollows.length,
+    };
+  };
+
+  const shouldShow = () => {
+    if (isCurrentUser()) return false;
+    if (!extension.isConnected()) return false;
+    if (loading()) return false;
+    const d = data();
+    return d !== null && d.score > 0;
+  };
+
+  const updateTooltipPosition = () => {
+    if (!badgeRef) return;
+    const rect = badgeRef.getBoundingClientRect();
+    setTooltipPos({
+      top: rect.top - 8,
+      left: rect.left + rect.width / 2,
+    });
+  };
+
+  const handleMouseEnter = () => {
+    updateTooltipPosition();
+    setShowTooltip(true);
+  };
+
+  const handleMouseLeave = () => {
+    setShowTooltip(false);
+  };
+
+  return (
+    <Show when={shouldShow()}>
+      <span
+        ref={badgeRef}
+        class={`${styles.wotBadge} ${score() <= 0 ? styles.badgeUnknown : ''}`}
+        style={badgeStyle()}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        {getDisplayText()}
+      </span>
+
+      <Show when={showTooltip()}>
+        <Portal>
+          <div
+            class={styles.tooltip}
+            style={{
+              top: `${tooltipPos().top}px`,
+              left: `${tooltipPos().left}px`,
+            }}
+          >
+            <div class={styles.tooltipContent}>
+              <Show when={tooltipData()}>
+                <div class={styles.tooltipTitle}>Web of Trust</div>
+                <div class={styles.tooltipStats}>
+                  <Show when={tooltipData()?.score}>
+                    <div class={styles.tooltipRow}>
+                      <span class={styles.tooltipLabel}>Trust</span>
+                      <span class={styles.tooltipValue}>{tooltipData()?.score}%</span>
+                    </div>
+                  </Show>
+                  <Show when={tooltipData()?.distance !== null}>
+                    <div class={styles.tooltipRow}>
+                      <span class={styles.tooltipLabel}>Distance</span>
+                      <span class={styles.tooltipValue}>
+                        {tooltipData()?.distance} hop{tooltipData()?.distance !== 1 ? 's' : ''}
+                      </span>
+                    </div>
+                  </Show>
+                  <Show when={tooltipData()?.paths && tooltipData()!.paths > 0}>
+                    <div class={styles.tooltipRow}>
+                      <span class={styles.tooltipLabel}>Paths</span>
+                      <span class={styles.tooltipValue}>{tooltipData()?.paths}</span>
+                    </div>
+                  </Show>
+                  <Show when={tooltipData()?.commonFollows && tooltipData()!.commonFollows > 0}>
+                    <div class={styles.tooltipRow}>
+                      <span class={styles.tooltipLabel}>Common follows</span>
+                      <span class={styles.tooltipValue}>{tooltipData()?.commonFollows}</span>
+                    </div>
+                  </Show>
+                </div>
+              </Show>
+              <Show when={!tooltipData()}>
+                <div class={styles.tooltipEmpty}>Not in your network</div>
+              </Show>
+            </div>
+          </div>
+        </Portal>
+      </Show>
+    </Show>
+  );
+};
+
+export default WotBadge;

--- a/src/contexts/WotContext.tsx
+++ b/src/contexts/WotContext.tsx
@@ -1,0 +1,310 @@
+/**
+ * WoT Context - thin wrapper around nostr-wot-sdk/solid
+ *
+ * This module re-exports SDK functionality and provides app-specific
+ * configuration (user pubkey fallback), caching, and batch fetching.
+ */
+import { createSignal, createEffect, onCleanup } from "solid-js";
+import {
+  WoTProvider as SdkWoTProvider,
+  useWoTContext as useSdkWoTContext,
+  useExtension as useSdkExtension,
+  useWoTInstance,
+  type WoTContextValue,
+  type ExtensionState,
+  type ExtensionConnectionState,
+} from "nostr-wot-sdk/solid";
+import { ContextChildren } from "../types/primal";
+import { accountStore } from "../stores/accountStore";
+
+// Re-export SDK hooks
+export { useWoTInstance };
+export type { WoTContextValue, ExtensionState, ExtensionConnectionState };
+
+// ============================================
+// WoT Cache and Batch Fetching
+// ============================================
+
+interface CachedWoTResult {
+  distance: number | null;
+  score: number;
+  paths: number;
+  commonFollows: string[];
+  timestamp: number;
+}
+
+// Global cache - persists across component unmounts
+const wotCache = new Map<string, CachedWoTResult>();
+const pendingPubkeys = new Set<string>();
+const subscribers = new Map<string, Set<() => void>>();
+const failedPubkeys = new Map<string, { retries: number; nextRetry: number }>();
+
+// Cache TTL: 5 minutes
+const CACHE_TTL = 5 * 60 * 1000;
+// Batch fetch delay: 100ms to collect multiple requests
+const BATCH_DELAY = 100;
+// Retry settings
+const MAX_RETRIES = 3;
+const BASE_RETRY_DELAY = 2000; // 2 seconds
+
+let batchTimeout: ReturnType<typeof setTimeout> | null = null;
+let retryTimeout: ReturnType<typeof setTimeout> | null = null;
+let wotInstanceRef: any = null;
+
+function isCacheValid(entry: CachedWoTResult): boolean {
+  return Date.now() - entry.timestamp < CACHE_TTL;
+}
+
+function notifySubscribers(pubkey: string) {
+  const subs = subscribers.get(pubkey);
+  if (subs) {
+    subs.forEach((cb) => cb());
+  }
+}
+
+async function executeBatchFetch() {
+  if (!wotInstanceRef || pendingPubkeys.size === 0) return;
+
+  const pubkeys = Array.from(pendingPubkeys);
+  pendingPubkeys.clear();
+
+  try {
+    // Use batch API to get distances and scores
+    const batchResults = await wotInstanceRef.batchCheck(pubkeys);
+
+    // Fetch common follows for each (in parallel)
+    const commonFollowsPromises = pubkeys.map(async (pk) => {
+      try {
+        return await wotInstanceRef.getCommonFollows(pk);
+      } catch {
+        return [];
+      }
+    });
+    const commonFollowsResults = await Promise.all(commonFollowsPromises);
+
+    // Update cache and notify subscribers, track failures
+    pubkeys.forEach((pk, i) => {
+      const result = batchResults.get(pk);
+      if (result) {
+        const details = {
+          distance: result.distance,
+          score: result.score,
+          paths: 0, // batchCheck doesn't return paths, would need getDetails
+          commonFollows: commonFollowsResults[i] || [],
+          timestamp: Date.now(),
+        };
+        wotCache.set(pk, details);
+        // Clear from failed tracking on success
+        failedPubkeys.delete(pk);
+        notifySubscribers(pk);
+      } else {
+        // Track failure for retry
+        trackFailure(pk);
+      }
+    });
+
+    // Schedule retry for failed pubkeys
+    scheduleRetry();
+  } catch (err) {
+    console.error('WoT batch fetch error:', err);
+    // On complete batch failure, track all pubkeys for retry
+    pubkeys.forEach((pk) => trackFailure(pk));
+    scheduleRetry();
+  }
+}
+
+function trackFailure(pubkey: string) {
+  const existing = failedPubkeys.get(pubkey);
+  if (existing) {
+    if (existing.retries < MAX_RETRIES) {
+      existing.retries++;
+      // Exponential backoff: 2s, 4s, 8s
+      existing.nextRetry = Date.now() + BASE_RETRY_DELAY * Math.pow(2, existing.retries - 1);
+    }
+  } else {
+    failedPubkeys.set(pubkey, {
+      retries: 1,
+      nextRetry: Date.now() + BASE_RETRY_DELAY,
+    });
+  }
+}
+
+function scheduleRetry() {
+  if (retryTimeout) return;
+
+  // Find the earliest retry time
+  let earliestRetry = Infinity;
+  failedPubkeys.forEach((info) => {
+    if (info.retries <= MAX_RETRIES && info.nextRetry < earliestRetry) {
+      earliestRetry = info.nextRetry;
+    }
+  });
+
+  if (earliestRetry === Infinity) return;
+
+  const delay = Math.max(0, earliestRetry - Date.now());
+  retryTimeout = setTimeout(() => {
+    retryTimeout = null;
+    executeRetry();
+  }, delay);
+}
+
+function executeRetry() {
+  const now = Date.now();
+  const toRetry: string[] = [];
+
+  failedPubkeys.forEach((info, pk) => {
+    if (info.retries <= MAX_RETRIES && info.nextRetry <= now) {
+      toRetry.push(pk);
+    }
+  });
+
+  if (toRetry.length > 0) {
+    // Add to pending and trigger batch fetch
+    toRetry.forEach((pk) => pendingPubkeys.add(pk));
+    scheduleBatchFetch();
+  }
+
+  // Schedule next retry if there are more
+  scheduleRetry();
+}
+
+function scheduleBatchFetch() {
+  if (batchTimeout) return;
+  batchTimeout = setTimeout(() => {
+    batchTimeout = null;
+    executeBatchFetch();
+  }, BATCH_DELAY);
+}
+
+function requestWoTData(pubkey: string, callback: () => void): () => void {
+  // Add subscriber
+  if (!subscribers.has(pubkey)) {
+    subscribers.set(pubkey, new Set());
+  }
+  subscribers.get(pubkey)!.add(callback);
+
+  // Check cache
+  const cached = wotCache.get(pubkey);
+  if (cached && isCacheValid(cached)) {
+    // Already have valid data, notify immediately
+    queueMicrotask(callback);
+  } else {
+    // Add to pending and schedule batch
+    pendingPubkeys.add(pubkey);
+    scheduleBatchFetch();
+  }
+
+  // Return cleanup function
+  return () => {
+    const subs = subscribers.get(pubkey);
+    if (subs) {
+      subs.delete(callback);
+      if (subs.size === 0) {
+        subscribers.delete(pubkey);
+      }
+    }
+  };
+}
+
+function getCachedWoT(pubkey: string): CachedWoTResult | null {
+  const cached = wotCache.get(pubkey);
+  if (cached && isCacheValid(cached)) {
+    return cached;
+  }
+  return null;
+}
+
+// ============================================
+// Exported Hooks and Components
+// ============================================
+
+/**
+ * App-specific WoT Provider
+ * Wraps SDK provider with user's pubkey as fallback
+ */
+export const WotProvider = (props: { children: ContextChildren }) => {
+  return (
+    <SdkWoTProvider
+      options={{
+        fallback: accountStore.publicKey ? { myPubkey: accountStore.publicKey } : undefined,
+      }}
+    >
+      {props.children}
+    </SdkWoTProvider>
+  );
+};
+
+/**
+ * Hook to access extension state
+ */
+export const useExtension = useSdkExtension;
+
+/**
+ * Hook to access full WoT context (SDK interface)
+ */
+export const useWoTContext = useSdkWoTContext;
+
+/**
+ * Compatibility hook for existing code
+ */
+export const useWotContext = () => {
+  const ctx = useSdkWoTContext();
+
+  return {
+    get wot() { return ctx.wot(); },
+    get isReady() { return ctx.isReady(); },
+    get extensionState() { return ctx.extension.state(); },
+    get isConnected() { return ctx.extension.isConnected(); },
+  };
+};
+
+/**
+ * Get current user's pubkey
+ */
+export const getMyPubkey = () => accountStore.publicKey;
+
+/**
+ * Hook to get cached WoT data for a pubkey with batch fetching
+ */
+export const useCachedWoT = (pubkey: () => string | undefined) => {
+  const wotInstance = useWoTInstance();
+  const extension = useSdkExtension();
+
+  const [data, setData] = createSignal<CachedWoTResult | null>(null);
+  const [loading, setLoading] = createSignal(true);
+
+  createEffect(() => {
+    const pk = pubkey();
+    const instance = wotInstance();
+
+    // Update global ref for batch fetcher
+    wotInstanceRef = instance;
+
+    if (!pk || !instance || !extension.isConnected()) {
+      setData(null);
+      setLoading(false);
+      return;
+    }
+
+    // Check cache first
+    const cached = getCachedWoT(pk);
+    if (cached) {
+      setData(cached);
+      setLoading(false);
+      return;
+    }
+
+    // Request data via batch system
+    setLoading(true);
+    const cleanup = requestWoTData(pk, () => {
+      const result = getCachedWoT(pk);
+      setData(result);
+      setLoading(false);
+    });
+
+    onCleanup(cleanup);
+  });
+
+  return { data, loading };
+};

--- a/src/pages/Explore/ExplorePeople.tsx
+++ b/src/pages/Explore/ExplorePeople.tsx
@@ -9,6 +9,7 @@ import Avatar from '../../components/Avatar/Avatar';
 import Paginator from '../../components/Paginator/Paginator';
 import FollowButton from '../../components/FollowButton/FollowButton';
 import VerificationCheck from '../../components/VerificationCheck/VerificationCheck';
+import WotBadge from '../../components/WotBadge/WotBadge';
 import { humanizeNumber } from '../../lib/stats';
 import { useAppContext } from '../../contexts/AppContext';
 import { accountStore } from '../../stores/accountStore';
@@ -72,6 +73,7 @@ const ExplorePeople: Component<{ open?: boolean }> = (props) => {
                     <div class={styles.userName}>
                       {userName(user)}
                       <VerificationCheck user={user} />
+                      <WotBadge pubkey={user.pubkey} />
                     </div>
                     <Show when={user.nip05}>
                       <div class={styles.nip05}>

--- a/src/pages/Longform.tsx
+++ b/src/pages/Longform.tsx
@@ -25,6 +25,7 @@ import NoteImage from "../components/NoteImage/NoteImage";
 import { nip19 } from "../lib/nTools";
 import { sortByRecency, convertToNotes, convertToArticles } from "../stores/note";
 import VerificationCheck from "../components/VerificationCheck/VerificationCheck";
+import WotBadge from "../components/WotBadge/WotBadge";
 import BookmarkArticle from "../components/BookmarkNote/BookmarkArticle";
 import NoteContextTrigger from "../components/Note/NoteContextTrigger";
 import { CustomZapInfo, useAppContext } from "../contexts/AppContext";
@@ -977,6 +978,9 @@ const Longform: Component< { naddr: string } > = (props) => {
                       <div class={styles.userName}>
                         {userName(store.article?.user)}
                         <VerificationCheck user={store.article?.user} />
+                        <Show when={store.article?.user?.pubkey}>
+                          <WotBadge pubkey={store.article!.user.pubkey} />
+                        </Show>
                       </div>
                       <Show when={store.article?.user.nip05}>
                         <div class={styles.nip05}>

--- a/src/pages/ProfileDesktop.tsx
+++ b/src/pages/ProfileDesktop.tsx
@@ -38,6 +38,7 @@ import { APP_ID } from '../App';
 import ProfileTabs from '../components/ProfileTabs/ProfileTabs';
 import ButtonSecondary from '../components/Buttons/ButtonSecondary';
 import VerificationCheck from '../components/VerificationCheck/VerificationCheck';
+import WotBadge from '../components/WotBadge/WotBadge';
 
 import PhotoSwipeLightbox from 'photoswipe/lightbox';
 import NoteImage from '../components/NoteImage/NoteImage';
@@ -871,6 +872,10 @@ const ProfileDesktop: Component = () => {
                           </div>
                         </Show>
 
+                        <Show when={profile?.profileKey}>
+                          <WotBadge pubkey={profile!.profileKey!} />
+                        </Show>
+
                         <Show when={isVisibleLegend()}>
                           <PremiumCohortInfo
                             user={profile?.userProfile}
@@ -962,6 +967,10 @@ const ProfileDesktop: Component = () => {
                           <div class={styles.vc}>
                             <VerificationCheck user={profile?.userProfile} large={true} />
                           </div>
+                        </Show>
+
+                        <Show when={profile?.profileKey}>
+                          <WotBadge pubkey={profile!.profileKey!} />
                         </Show>
 
                         <Show when={isVisibleLegend()}>

--- a/src/pages/ProfileMobile.tsx
+++ b/src/pages/ProfileMobile.tsx
@@ -31,6 +31,7 @@ import { APP_ID } from '../App';
 import ProfileTabs from '../components/ProfileTabs/ProfileTabs';
 import ButtonSecondary from '../components/Buttons/ButtonSecondary';
 import VerificationCheck from '../components/VerificationCheck/VerificationCheck';
+import WotBadge from '../components/WotBadge/WotBadge';
 
 import PhotoSwipeLightbox from 'photoswipe/lightbox';
 import NoteImage from '../components/NoteImage/NoteImage';
@@ -830,6 +831,10 @@ const ProfileMobile: Component = () => {
                     <div class={styles.vc}>
                       <VerificationCheck user={profile?.userProfile} large={true} />
                     </div>
+                  </Show>
+
+                  <Show when={profile?.profileKey}>
+                    <WotBadge pubkey={profile!.profileKey!} />
                   </Show>
 
                   <Show when={isVisibleLegend()}>

--- a/src/pages/Settings/Menu.tsx
+++ b/src/pages/Settings/Menu.tsx
@@ -7,11 +7,13 @@ import PageCaption from '../../components/PageCaption/PageCaption';
 import { A, useNavigate } from '@solidjs/router';
 import ButtonPrimary from '../../components/Buttons/ButtonPrimary';
 import { accountStore, hasPublicKey, logout } from '../../stores/accountStore';
+import { useExtension } from '../../contexts/WotContext';
 
 const Menu: Component = () => {
 
   const intl = useIntl();
   const navigate = useNavigate();
+  const extension = useExtension();
 
   const version = import.meta.env.PRIMAL_VERSION;
 
@@ -80,6 +82,16 @@ const Menu: Component = () => {
 
         <A href="/settings/network">
           {intl.formatMessage(t.network.title)}
+          <div class={styles.chevron}></div>
+        </A>
+
+        <A href="/settings/wot">
+          {intl.formatMessage(t.webOfTrust.title)}
+          <Show when={extension.isConnected()}>
+            <div class={styles.bubble}>
+              <div></div>
+            </div>
+          </Show>
           <div class={styles.chevron}></div>
         </A>
 

--- a/src/pages/Settings/Settings.module.scss
+++ b/src/pages/Settings/Settings.module.scss
@@ -1317,3 +1317,164 @@
   gap: 8px;
   margin: 20px;
 }
+
+// Web of Trust styles
+.settingsContentSection {
+  margin-top: 24px;
+}
+
+.settingsContentSectionTitle {
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 20px;
+  color: var(--text-primary);
+  margin-bottom: 12px;
+}
+
+.wotStatus {
+  padding: 12px 16px;
+  background: var(--background-input);
+  border-radius: 8px;
+  margin-bottom: 16px;
+}
+
+.wotStatusConnected {
+  color: var(--success-color, #22c55e);
+  font-weight: 600;
+}
+
+.wotStatusNotAvailable {
+  color: var(--text-tertiary);
+  font-weight: 600;
+}
+
+.wotStatusChecking {
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.wotInstallPrompt {
+  padding: 16px;
+  background: var(--background-input);
+  border-radius: 8px;
+
+  p {
+    margin: 0 0 16px 0;
+    color: var(--text-secondary);
+    font-size: 14px;
+    line-height: 1.5;
+  }
+}
+
+.wotInstallButton {
+  display: inline-block;
+  padding: 10px 20px;
+  background: var(--accent);
+  color: var(--text-primary-button);
+  border-radius: 8px;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 14px;
+
+  &:hover {
+    opacity: 0.9;
+  }
+}
+
+.wotInfo {
+  padding: 16px;
+  background: var(--background-input);
+  border-radius: 8px;
+
+  p {
+    margin: 0 0 16px 0;
+    color: var(--text-secondary);
+    font-size: 14px;
+    line-height: 1.5;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
+.wotHint {
+  margin-top: 16px !important;
+  font-size: 13px !important;
+  color: var(--text-tertiary) !important;
+  font-style: italic;
+}
+
+.wotGradientSection {
+  margin-bottom: 20px;
+}
+
+.wotGradientLabel {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 10px;
+}
+
+.wotGradientBar {
+  height: 12px;
+  border-radius: 6px;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+.wotGradientMarkers {
+  position: relative;
+  height: 28px;
+  margin-top: 4px;
+}
+
+.wotGradientMarker {
+  position: absolute;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.wotMarkerTick {
+  width: 1px;
+  height: 6px;
+  background: var(--text-tertiary);
+}
+
+.wotMarkerLabel {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  margin-top: 2px;
+}
+
+.wotLegend {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+.wotLegendItem {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+.wotBadgeSample {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 10px;
+  font-size: 12px;
+  font-weight: 600;
+  color: white;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}

--- a/src/pages/Settings/WebOfTrust.tsx
+++ b/src/pages/Settings/WebOfTrust.tsx
@@ -1,0 +1,144 @@
+import { Component, For, Show, Switch, Match } from 'solid-js';
+import styles from './Settings.module.scss';
+
+import { useIntl } from '@cookbook/solid-intl';
+import { settings as t } from '../../translations';
+import PageCaption from '../../components/PageCaption/PageCaption';
+import { A } from '@solidjs/router';
+import PageTitle from '../../components/PageTitle/PageTitle';
+import { useExtension } from '../../contexts/WotContext';
+
+// Same color stops as WotBadge
+const colorStops = [
+  { score: 0, label: '0', color: '#6b7280' },    // Gray
+  { score: 50, label: '50', color: '#f59e0b' },  // Orange
+  { score: 65, label: '65', color: '#eab308' },  // Yellow
+  { score: 70, label: '70', color: '#22c55e' },  // Green
+  { score: 100, label: '100', color: '#38bdf8' }, // Light blue
+];
+
+const WebOfTrust: Component = () => {
+  const intl = useIntl();
+  const extension = useExtension();
+
+  const extensionUrl = 'https://chromewebstore.google.com/detail/nostr-wot/placeholder';
+
+  // Generate CSS gradient from color stops
+  const gradientStyle = () => {
+    const stops = colorStops.map(stop => `${stop.color} ${stop.score}%`).join(', ');
+    return `linear-gradient(to right, ${stops})`;
+  };
+
+  return (
+    <div>
+      <PageTitle title={`${intl.formatMessage(t.webOfTrust.title)} ${intl.formatMessage(t.title)}`} />
+
+      <PageCaption>
+        <A href='/settings' >{intl.formatMessage(t.index.title)}</A>:&nbsp;
+        <div>{intl.formatMessage(t.webOfTrust.title)}</div>
+      </PageCaption>
+
+      <div class={styles.settingsContent}>
+        <div class={styles.settingsCaption}>
+          {intl.formatMessage(t.webOfTrust.description)}
+        </div>
+
+        <div class={styles.settingsContentSection}>
+          <div class={styles.settingsContentSectionTitle}>
+            {intl.formatMessage(t.webOfTrust.extensionStatus)}
+          </div>
+
+          <div class={styles.wotStatus}>
+            <Switch>
+              <Match when={extension.isChecking()}>
+                <span class={styles.wotStatusChecking}>
+                  {intl.formatMessage(t.webOfTrust.checking)}
+                </span>
+              </Match>
+              <Match when={extension.isConnected()}>
+                <span class={styles.wotStatusConnected}>
+                  {intl.formatMessage(t.webOfTrust.connected)}
+                </span>
+              </Match>
+              <Match when={!extension.isConnected()}>
+                <span class={styles.wotStatusNotAvailable}>
+                  {intl.formatMessage(t.webOfTrust.notAvailable)}
+                </span>
+              </Match>
+            </Switch>
+          </div>
+
+          <Show when={!extension.isConnected() && !extension.isChecking()}>
+            <div class={styles.wotInstallPrompt}>
+              <p>
+                To use Web of Trust features, install the nostr-wot browser extension.
+                The extension builds a local copy of your follow graph for fast, private trust calculations.
+              </p>
+              <a
+                href={extensionUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                class={styles.wotInstallButton}
+              >
+                {intl.formatMessage(t.webOfTrust.installExtension)}
+              </a>
+            </div>
+          </Show>
+
+          <Show when={extension.isConnected()}>
+            <div class={styles.wotInfo}>
+              <p>
+                Web of Trust badges are visible next to user names throughout the app.
+                The badge color changes smoothly based on trust score.
+              </p>
+
+              <div class={styles.wotGradientSection}>
+                <div class={styles.wotGradientLabel}>Trust Score Scale</div>
+                <div class={styles.wotGradientBar} style={{ background: gradientStyle() }}></div>
+                <div class={styles.wotGradientMarkers}>
+                  <For each={colorStops}>
+                    {(stop) => (
+                      <div class={styles.wotGradientMarker} style={{ left: `${stop.score}%` }}>
+                        <div class={styles.wotMarkerTick}></div>
+                        <div class={styles.wotMarkerLabel}>{stop.label}</div>
+                      </div>
+                    )}
+                  </For>
+                </div>
+              </div>
+
+              <div class={styles.wotLegend}>
+                <div class={styles.wotLegendItem}>
+                  <span class={styles.wotBadgeSample} style={{ background: '#6b7280' }}>15</span>
+                  <span>Low trust - Distant connections</span>
+                </div>
+                <div class={styles.wotLegendItem}>
+                  <span class={styles.wotBadgeSample} style={{ background: '#f59e0b' }}>50</span>
+                  <span>Moderate trust - Extended network</span>
+                </div>
+                <div class={styles.wotLegendItem}>
+                  <span class={styles.wotBadgeSample} style={{ background: '#eab308' }}>65</span>
+                  <span>Good trust - Friends of friends</span>
+                </div>
+                <div class={styles.wotLegendItem}>
+                  <span class={styles.wotBadgeSample} style={{ background: '#22c55e' }}>75</span>
+                  <span>High trust - Closer connections</span>
+                </div>
+                <div class={styles.wotLegendItem}>
+                  <span class={styles.wotBadgeSample} style={{ background: '#38bdf8' }}>100</span>
+                  <span>Maximum trust - Direct follows, or followed by a lot of direct follows</span>
+                </div>
+              </div>
+
+              <p class={styles.wotHint}>
+                Hover over any badge to see detailed info: trust %, hops, paths, and common follows.
+              </p>
+            </div>
+          </Show>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WebOfTrust;

--- a/src/translations.ts
+++ b/src/translations.ts
@@ -1979,6 +1979,53 @@ export const settings = {
     defaultMessage: 'Dev Tools',
     description: 'Title of the dev tools section on the settings page',
   },
+  webOfTrust: {
+    title: {
+      id: 'settings.webOfTrust.title',
+      defaultMessage: 'Web of Trust',
+      description: 'Title of the Web of Trust settings sub-page',
+    },
+    description: {
+      id: 'settings.webOfTrust.description',
+      defaultMessage: 'Web of Trust shows trust indicators based on your social graph. Install the nostr-wot browser extension to enable this feature.',
+      description: 'Description of the Web of Trust settings',
+    },
+    extensionStatus: {
+      id: 'settings.webOfTrust.extensionStatus',
+      defaultMessage: 'Extension Status',
+      description: 'Label for extension status section',
+    },
+    connected: {
+      id: 'settings.webOfTrust.connected',
+      defaultMessage: 'Connected',
+      description: 'Status when extension is connected',
+    },
+    notAvailable: {
+      id: 'settings.webOfTrust.notAvailable',
+      defaultMessage: 'Not Available',
+      description: 'Status when extension is not available',
+    },
+    checking: {
+      id: 'settings.webOfTrust.checking',
+      defaultMessage: 'Checking...',
+      description: 'Status when checking for extension',
+    },
+    installExtension: {
+      id: 'settings.webOfTrust.installExtension',
+      defaultMessage: 'Install Extension',
+      description: 'Button to install the extension',
+    },
+    trustDistance: {
+      id: 'settings.webOfTrust.trustDistance',
+      defaultMessage: 'Trust Distance',
+      description: 'Label for trust distance indicator',
+    },
+    trustScore: {
+      id: 'settings.webOfTrust.trustScore',
+      defaultMessage: 'Trust Score',
+      description: 'Label for trust score indicator',
+    },
+  },
   notifications: {
     title: {
       id: 'pages.settings.sections.notifications',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "node", // or whatever works for @cookbook/solid-intl
+    "moduleResolution": "bundler",
     "paths": {
       "nostr-tools/nip46": ["./node_modules/nostr-tools/lib/esm/nip46.js"]
     },


### PR DESCRIPTION
## Summary

This PR adds optional Web of Trust (WoT) integration using the `nostr-wot-sdk` package. Trust badges appear throughout the app only when the user has the nostr-wot browser extension installed and connected.

https://nostr-wot.com
https://github.com/nostr-wot/nostr-wot-sdk
https://github.com/nostr-wot/nostr-wot-extension

> Extension available for Chrome and Firefox (including all chromium: Brave, Opera, Edge).
> Attached images at the end of the descriptionn.

### Features
- **WotBadge component** with continuous color gradient based on trust score (0-100)
- **Custom tooltip** showing trust %, distance (hops), paths, and common follows
- **Batch fetching with caching** to avoid rate limiting the extension
- **Retry logic with exponential backoff** for failed requests (3 retries: 2s → 4s → 8s)
- **Settings page** at `/settings/wot` with trust scale visualization and extension status

### Badge locations
- Profile pages (desktop and mobile)
- Note headers and author info
- Reads/articles feed and sidebar (ArticlePreview, ArticleShort, ArticleCompactPreview)
- Explore/people section
- Notifications (all tabs: all, zaps, replies, mentions, reposts)
- Direct messages contacts
- Followers/following modal (ProfileContact)
- Profile zaps (ProfileNoteZap)
- Trending feed sidebar (SmallNote)
- Live events sidebar (LivePill)
- Featured author in reads sidebar (AuthorSubscribe)

### Color scale
| Score | Color |
|-------|-------|
| 0 | Gray (#6b7280) |
| 50 | Orange (#f59e0b) |
| 65 | Yellow (#eab308) |
| 70 | Green (#22c55e) |
| 100 | Light Blue (#38bdf8) |

Colors interpolate smoothly between these stops.

### Technical details
- Badges are hidden for the current user
- Cache TTL: 5 minutes
- Batch delay: 100ms to collect multiple requests
- Uses SolidJS Portal for tooltips to escape overflow:hidden containers
- TypeScript moduleResolution changed to "bundler" to support package subpath exports

## Test plan
- [ ] Without extension: App loads normally, no WoT UI visible anywhere
- [ ] With extension installed but not connected: No WoT UI (graceful degradation)
- [ ] With extension connected:
  - [ ] WoT badge appears on profile pages
  - [ ] WoT badge appears next to note authors in feeds
  - [ ] WoT badge appears in people lists
  - [ ] WoT badge appears in reads/articles
  - [ ] WoT badge appears in notifications (all tabs)
  - [ ] WoT badge appears in DM contacts
  - [ ] WoT badge appears in trending sidebar
  - [ ] Settings menu shows "Web of Trust" option
  - [ ] Settings page displays extension status and color scale
  - [ ] Tooltip shows on hover with trust details
- [ ] Badges display in a row (not stacked) next to other badges
- [ ] Failed requests are retried automatically

<img width="1193" height="782" alt="Screenshot 2026-02-22 at 13 39 37" src="https://github.com/user-attachments/assets/3bc2ec6e-8e82-4966-a438-b3fddc377423" />

<img width="1019" height="804" alt="Screenshot 2026-02-22 at 13 40 51" src="https://github.com/user-attachments/assets/f1935b7c-1b5a-40d8-b92a-8780784f3b9f" />

<img width="948" height="849" alt="Screenshot 2026-02-22 at 13 39 46" src="https://github.com/user-attachments/assets/eee3f2c1-f847-4ae7-ad8e-c46a29a80048" />

<img width="1306" height="844" alt="Screenshot 2026-02-22 at 13 43 25" src="https://github.com/user-attachments/assets/1d0d624d-fc97-4cdb-8c0f-c26236bcf3a2" />

<img width="984" height="828" alt="Screenshot 2026-02-22 at 13 31 36" src="https://github.com/user-attachments/assets/d0b9b2cb-3d2f-4a4b-a719-c29a3b223d10" />

