### PR TITLE
Add 'Keep web link' toggle to post composer

### DIFF
--- a/src/components/NewNote/EditBox/EditBox.module.scss
+++ b/src/components/NewNote/EditBox/EditBox.module.scss
@@ -66,6 +66,13 @@
 
 }
 
+.webLinkToggle {
+  display: flex;
+  align-items: center;
+  margin-right: 8px;
+  white-space: nowrap;
+}
+
 .controls {
   position: absolute;
   bottom: 4px;

--- a/src/components/NewNote/EditBox/EditBox.tsx
+++ b/src/components/NewNote/EditBox/EditBox.tsx
@@ -75,6 +75,8 @@ import SimpleArticlePreview from "../../ArticlePreview/SimpleArticlePreview";
 import ArticleHighlight from "../../ArticleHighlight/ArticleHighlight";
 import DOMPurify from "dompurify";
 import { useAppContext } from "../../../contexts/AppContext";
+import { checkForNostrWebLinks, convertNostrWebLinksToNative } from "../../../lib/nostrLinks";
+import CheckBox from "../../Checkbox/CheckBox";
 import UploaderBlossom from "../../Uploader/UploaderBlossom";
 import LiveEventPreview from "../../LiveVideo/LiveEventPreview";
 import { StreamingData, getStreamingEvent } from "../../../lib/streaming";
@@ -126,6 +128,10 @@ const EditBox: Component<{
   const [isEmojiInput, setEmojiInput] = createSignal(false);
   const [emojiQuery, setEmojiQuery] = createSignal('');
   const [emojiResults, setEmojiResults] = createStore<EmojiOption[]>([]);
+
+  const [preserveWebLinks, setPreserveWebLinks] = createSignal(false);
+  const hasNostrWebLinks = () => checkForNostrWebLinks(message());
+  const showWebLinkToggle = () => preserveWebLinks() || hasNostrWebLinks();
 
   const [userRefs, setUserRefs] = createStore<Record<string, PrimalUser>>({});
   const [noteRefs, setNoteRefs] = createStore<Record<string, PrimalNote>>({});
@@ -696,6 +702,7 @@ const EditBox: Component<{
     setEmojiInput(false);
     setEmojiQuery('')
     setEmojiResults(() => []);
+    setPreserveWebLinks(false);
 
     resetUpload();
 
@@ -806,8 +813,12 @@ const EditBox: Component<{
       return `${anythingBefore}nostr:${nprofile}`;
     });
 
+    const finalMessage = preserveWebLinks()
+      ? messageToSend
+      : convertNostrWebLinksToNative(messageToSend);
+
     if (accountStore) {
-      let tags = referencesToTags(messageToSend, relayHints);
+      let tags = referencesToTags(finalMessage, relayHints);
       const rep = props.replyToNote;
 
       // @ts-ignore
@@ -913,7 +924,7 @@ const EditBox: Component<{
       setIsPostingInProgress(true);
 
       const { success, reasons, note } = await sendNote(
-        messageToSend,
+        finalMessage,
         tags,
       );
 
@@ -1579,7 +1590,8 @@ const EditBox: Component<{
     if (delayForMedia) {
       window.clearTimeout(delayForMedia);
     }
-    const msg = sanitize(message());
+    const raw = sanitize(message());
+    const msg = preserveWebLinks() ? raw : convertNostrWebLinksToNative(raw);
 
     delayForMedia = setTimeout(async () => {
       const p = await parseForReferece(msg);
@@ -2053,6 +2065,15 @@ const EditBox: Component<{
             </Show>
           </div>
         </div>
+        <Show when={showWebLinkToggle()}>
+          <div class={styles.webLinkToggle}>
+            <CheckBox
+              checked={preserveWebLinks()}
+              onChange={(v: boolean) => setPreserveWebLinks(v)}
+              label={intl.formatMessage(tActions.keepWebLink)}
+            />
+          </div>
+        </Show>
         <div class={styles.editorDescision}>
           <ButtonPrimary
             onClick={postNote}

--- a/src/lib/nostrLinks.ts
+++ b/src/lib/nostrLinks.ts
@@ -1,0 +1,81 @@
+import { nip19 } from './nTools';
+import { urlRegexG } from '../constants';
+
+const bech32Chars = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+const nip19Prefixes = ['nevent1', 'npub1', 'nprofile1', 'naddr1', 'note1'];
+
+const nip19InUrlRegex = new RegExp(
+  `\\b(${nip19Prefixes.join('|')})([${bech32Chars}]+)`, 'i'
+);
+
+/** Extract a valid NIP-19 bech32 identifier from a URL string. Returns null if none found. */
+function extractBech32FromUrl(url: string): string | null {
+  const match = url.match(nip19InUrlRegex);
+  if (!match) return null;
+
+  const candidate = match[1] + match[2];
+
+  try {
+    nip19.decode(candidate);
+    return candidate;
+  } catch {
+    return null;
+  }
+}
+
+/** Returns true if text contains any HTTP(S) URL with a NIP-19 bech32 identifier. */
+export function checkForNostrWebLinks(text: string): boolean {
+  const urlMatches = text.match(urlRegexG);
+  if (!urlMatches) return false;
+
+  for (const url of urlMatches) {
+    if (extractBech32FromUrl(url) !== null) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Replaces HTTP(S) URLs containing NIP-19 bech32 identifiers with nostr:{bech32}.
+ * Validates each with nip19.decode(). Skips nsec1.
+ */
+export function convertNostrWebLinksToNative(content: string): string {
+  const matches: { index: number; length: number; replacement: string }[] = [];
+
+  let match: RegExpExecArray | null;
+  const regex = new RegExp(urlRegexG.source, urlRegexG.flags);
+
+  while ((match = regex.exec(content)) !== null) {
+    const url = match[0];
+
+    // Skip nostr: scheme URLs
+    if (/^nostr:/i.test(url)) continue;
+
+    // Skip URLs containing nsec1
+    if (/nsec1/i.test(url)) continue;
+
+    const bech32 = extractBech32FromUrl(url);
+    if (bech32) {
+      // Preserve trailing punctuation that urlRegexG absorbed from surrounding text
+      const punctMatch = url.match(/[.,;!?)]+$/);
+      const suffix = punctMatch ? punctMatch[0] : '';
+
+      matches.push({
+        index: match.index,
+        length: url.length,
+        replacement: `nostr:${bech32}${suffix}`,
+      });
+    }
+  }
+
+  // Process replacements back-to-front to preserve string indices
+  let result = content;
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const m = matches[i];
+    result = result.slice(0, m.index) + m.replacement + result.slice(m.index + m.length);
+  }
+
+  return result;
+}

--- a/src/translations.ts
+++ b/src/translations.ts
@@ -291,6 +291,11 @@ export const actions = {
     defaultMessage: 'Copy Primal link',
     description: 'Label for the copy Primal note link context menu item',
   },
+  keepWebLink: {
+    id: 'actions.keepWebLink',
+    defaultMessage: 'Keep web link',
+    description: 'Toggle label for preserving web links instead of converting to nostr: format',
+  },
   notePostNew: {
     id: 'actions.notePostNew',
     defaultMessage: 'Post',


### PR DESCRIPTION

<img width="323" height="288" alt="Screenshot 2026-03-05 at 1 08 52 PM" src="https://github.com/user-attachments/assets/1fb66fe1-922b-476b-ba5e-ac717e0c7aa5" />

<img width="535" height="210" alt="Screenshot 2026-03-05 at 1 03 41 PM" src="https://github.com/user-attachments/assets/8cc8b3d5-edd0-45dd-83a8-b7b3f6dd05b6" />

<img width="324" height="306" alt="Screenshot 2026-03-05 at 2 13 55 PM" src="https://github.com/user-attachments/assets/fdba4fa8-06d1-493f-b5fc-13e2a115c336" />

<img width="320" height="180" alt="Screenshot 2026-03-05 at 2 14 05 PM" src="https://github.com/user-attachments/assets/0470bf12-1b68-4776-9de5-a0b33bacc1c3" />

## Summary

- When users paste URLs containing NIP-19 bech32 identifiers (e.g. `njump.me/nevent1...`, `primal.net/e/note1...`), the composer now converts them to `nostr:` format by default before publishing
- Adds a "Keep web link" checkbox so users can opt to preserve the original HTTP URL
- Preview reflects the conversion: shows embedded note when converting, shows link when keeping

## Details

**New utility** (`src/lib/nostrLinks.ts`):
- `checkForNostrWebLinks()` — detects HTTP URLs containing NIP-19 identifiers
- `convertNostrWebLinksToNative()` — replaces HTTP URLs with `nostr:{bech32}` format
- Validates each identifier via `nip19.decode()`; skips `nsec1` for safety
- Preserves trailing sentence punctuation absorbed by URL regex
- Word-boundary-safe matching to avoid false positives

**Composer integration** (`EditBox.tsx`):
- Toggle appears inline in the controls bar when a nostr web link is detected
- Conversion applied in both preview pipeline and `postNote()`
- Toggle state resets on clear/post

## Test plan

- [ ] Paste `https://njump.me/nevent1...` — checkbox appears, preview shows embedded note
- [ ] Post without checking box — published content has `nostr:nevent1...`
- [ ] Check box and post — published content has the full HTTP URL
- [ ] Paste `https://example.com` — no checkbox appears
- [ ] Remove nostr URL from textarea (unchecked) — checkbox disappears
- [ ] Paste URL ending with period (`https://njump.me/nevent1....`) — period preserved
- [ ] URL containing `nsec1` — never converted

🤖 Generated with [Claude Code](https://claude.com/claude-code)