### PR TITLE
fix: use Unicode ZWSP instead of HTML entity in markdown content

### DIFF
--- a/src/components/PrimalMarkdown/MarkdownEditor.tsx
+++ b/src/components/PrimalMarkdown/MarkdownEditor.tsx
@@ -54,7 +54,7 @@ const MarkdownSlice: Component<{
       const cont = props.content.replace(regex, (e) => {
         const arr = e.split('@');
 
-        return `${arr[0]}&#8203;@${arr[1]}`;
+        return `${arr[0]}\u200B@${arr[1]}`;
       });
 
       insert(cont)(e.ctx);

--- a/src/components/PrimalMarkdown/MarkdownSlice.tsx
+++ b/src/components/PrimalMarkdown/MarkdownSlice.tsx
@@ -56,7 +56,7 @@ const MarkdownSlice: Component<{
       let cont = props.content.replace(regex, (e) => {
         const arr = e.split('@');
 
-        return `${arr[0]}&#8203;@${arr[1]}`;
+        return `${arr[0]}\u200B@${arr[1]}`;
       });
 
       // Replace single line breaks with spaces


### PR DESCRIPTION
## Problem

The email regex handler in `MarkdownSlice.tsx` and `MarkdownEditor.tsx` inserts a zero-width space before `@` to prevent Milkdown from treating email-like patterns as mentions. However, it uses the **HTML entity** `&#8203;` which gets inserted into the **markdown source text** passed to Milkdown's `insert()`.

Since `insert()` processes markdown (not HTML), the entity is never interpreted — it passes through as literal text and renders as visible `&#8203;` characters in articles.

**Example:** https://primal.net/a/naddr1qvzqqqr4gupzqscctm0vke6cj2pykx3h54lnusrlhh3wxmfeqrguznwx0fwnutd8sqq3kuctdv43k76tw945kuar9vaexzarfdahz6ctdv46xs7tnwskkwatfv3jsz0753t

The raw event content (verified via relay) contains no `&#8203;` — it's injected client-side by the regex replacement.

## Fix

Replace the HTML entity string `&#8203;` with the actual Unicode zero-width space character (`\u200B`), which is invisible in both markdown source and HTML rendering.

## Files Changed

- `src/components/PrimalMarkdown/MarkdownSlice.tsx` (read-only article view)
- `src/components/PrimalMarkdown/MarkdownEditor.tsx` (editor)