### PR TITLE
Make Stripe.js loading opt-out via PRIMAL_ENABLE_STRIPE

### DIFF
--- a/src/pages/Premium/Premium.tsx
+++ b/src/pages/Premium/Premium.tsx
@@ -56,7 +56,7 @@ import PremiumManageModal from './PremiumManageModal';
 import PremiumLegendLeaderBoard from './PremiumLegendLeaderboard';
 import PremiumStripeModal from './PremiumStripeModal';
 import PrimalProInfoDialog from './PrimalProInfoDialog';
-import {loadStripe, Stripe} from '@stripe/stripe-js';
+import {loadStripe, Stripe} from '@stripe/stripe-js/pure';
 import PremiumFailModal from './PremiumFailModal';
 import { accountStore, clearPremiumRemider, hasPublicKey, showGetStarted, updateAccountProfile } from '../../stores/accountStore';
 
@@ -176,6 +176,10 @@ const Premium: Component = () => {
   const [stripe, setStripe] = createSignal<Stripe>();
 
   const initStripe = async () => {
+    // Deployments that don't use Primal's hosted card payments (e.g. self-hosted
+    // builds) can set PRIMAL_ENABLE_STRIPE=false to skip loading Stripe.js from
+    // js.stripe.com entirely. Defaults to enabled when the flag is unset.
+    if (import.meta.env.PRIMAL_ENABLE_STRIPE === 'false') return;
     const stripe = await loadStripe('pk_live_51RVHYpFwkeNa1BHGECLthTjCyKDMtxQKCvIELbfjm1eE5yMMSwkJB44zcbioVWDCLhpKpkbL3wVhfWGvp6NTyHjf00TSUW1RVL');
     // @ts-ignore
     setStripe(stripe);

--- a/src/pages/Premium/PremiumStripeModal.tsx
+++ b/src/pages/Premium/PremiumStripeModal.tsx
@@ -5,7 +5,7 @@ import QrCode from '../../components/QrCode/QrCode';
 import TransactionAmount from '../../components/TransactionAmount/TransactionAmount';
 import { PrimalPremiumSubscription, PremiumStore } from './Premium';
 
-import { Stripe, StripeEmbeddedCheckout } from '@stripe/stripe-js';
+import { Stripe, StripeEmbeddedCheckout } from '@stripe/stripe-js/pure';
 import styles from './Premium.module.scss';
 import { subsTo } from '../../sockets';
 import { subTo } from '../../lib/sockets';


### PR DESCRIPTION
## Summary

The Premium page eagerly loads Stripe.js from `js.stripe.com` on mount. Importing the default `@stripe/stripe-js` entry also injects the loader `<script>` as an *import side effect*, so the request to `js.stripe.com/basil/stripe.js` fires even before `loadStripe()` is called.

Deployments that don't use Primal's hosted card payments — self-hosted builds, offline/air-gapped use — currently have no way to suppress this third-party request.

This change makes Stripe.js loading **opt-out** behind a build-time flag:

- Switch `Premium.tsx` / `PremiumStripeModal.tsx` to the side-effect-free `@stripe/stripe-js/pure` entry, so merely importing the module no longer injects the loader.
- Gate the `loadStripe()` call behind `import.meta.env.PRIMAL_ENABLE_STRIPE`. Setting `PRIMAL_ENABLE_STRIPE=false` skips Stripe.js entirely.

The flag is **default-on**: when unset (or any value other than `false`) behavior is unchanged, so this is a no-op for primal.net and any existing build. With `PRIMAL_ENABLE_STRIPE=false`, Vite statically replaces the check at build time and the `loadStripe` call (and the `@stripe/stripe-js/pure` module) are dead-code-eliminated — verified that the production bundle then contains zero references to `js.stripe.com`.

Only the browser-side Stripe.js loader is affected; the relay-based membership APIs (`initStripe`/`resolveStripe`) are untouched.