### PR TITLE
feat: add configurable inline note translation

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -49,6 +49,7 @@ const DevTools = lazy(() => import('./pages/Settings/DevTools'));
 const ZapSettings = lazy(() => import('./pages/Settings/Zaps'));
 const Muted = lazy(() => import('./pages/Settings/Muted'));
 const Network = lazy(() => import('./pages/Settings/Network'));
+const TranslationSettings = lazy(() => import('./pages/Settings/Translation'));
 const Moderation = lazy(() => import('./pages/Settings/Moderation'));
 const NostrWalletConnect = lazy(() => import('./pages/Settings/NostrWalletConnect'));
 const Menu = lazy(() => import('./pages/Settings/Menu'));
@@ -162,6 +163,7 @@ const AppRouter: Component = () => {
             <Route path="/zaps" component={ZapSettings} />
             <Route path="/muted" component={Muted} />
             <Route path="/network" component={Network} />
+            <Route path="/translation" component={TranslationSettings} />
             <Route path="/filters" component={Moderation} />
             <Route path="/nwc" component={NostrWalletConnect} />
             <Route path="/devtools" component={DevTools} />

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -19,6 +19,7 @@ import { date, veryLongDate } from '../../lib/dates';
 import { isPhone, uuidv4 } from '../../utils';
 import NoteTopZaps from './NoteTopZaps';
 import NoteTopZapsCompact from './NoteTopZapsCompact';
+import NoteTranslation from './NoteTranslation';
 import { addrRegexG, imageRegexG, linebreakRegex, noteRegex, urlRegexG } from '../../constants';
 import { TranslatorProvider } from '../../contexts/TranslatorContext';
 import { accountStore } from '../../stores/accountStore';
@@ -414,6 +415,13 @@ const Note: Component<NoteProps> = (props) => {
               />
             </div>
 
+            <NoteTranslation
+              note={props.note}
+              width={Math.min(598, window.innerWidth)}
+              margins={isPhone() ? 42 : 1}
+              primary={true}
+            />
+
             <div class={styles.topZaps}>
               <NoteTopZaps
                 topZaps={reactionsState.topZapsFeed}
@@ -557,6 +565,12 @@ const Note: Component<NoteProps> = (props) => {
             />
           </div>
 
+          <NoteTranslation
+            note={props.note}
+            width={window.innerWidth}
+            margins={45}
+          />
+
           <NoteTopZapsCompact
             note={props.note}
             action={() => openReactionModal('zaps')}
@@ -643,6 +657,13 @@ const Note: Component<NoteProps> = (props) => {
                   footerSize="short"
                 />
               </div>
+
+              <NoteTranslation
+                note={props.note}
+                width={Math.min(510, window.innerWidth - 72)}
+                margins={1}
+                footerSize="short"
+              />
 
               <NoteTopZapsCompact
                 note={props.note}
@@ -759,6 +780,13 @@ const Note: Component<NoteProps> = (props) => {
                   footerSize="short"
                 />
               </div>
+
+              <NoteTranslation
+                note={props.note}
+                width={Math.min(508, window.innerWidth - 72)}
+                margins={58}
+                footerSize="short"
+              />
             </div>
           </div>
         </div>

--- a/src/components/Note/NotePrimary/NotePrimary.tsx
+++ b/src/components/Note/NotePrimary/NotePrimary.tsx
@@ -4,6 +4,7 @@ import { PrimalNote } from '../../../types/primal';
 import ParsedNote from '../../ParsedNote/ParsedNote';
 import NoteFooter from '../NoteFooter/NoteFooter';
 import NoteHeader from '../NoteHeader/NoteHeader';
+import NoteTranslation from '../NoteTranslation';
 
 import styles from './NotePrimary.module.scss';
 
@@ -24,6 +25,8 @@ const NotePrimary: Component<{ note: PrimalNote, id?: string }> = (props) => {
         <div class={styles.message}>
           <ParsedNote note={props.note} width={Math.min(574, window.innerWidth)} />
         </div>
+
+        <NoteTranslation note={props.note} width={Math.min(574, window.innerWidth)} />
 
         <NoteFooter note={props.note} wide={true} />
       </div>

--- a/src/components/Note/NoteTranslation.module.scss
+++ b/src/components/Note/NoteTranslation.module.scss
@@ -1,0 +1,75 @@
+.translation {
+  width: 100%;
+  margin-top: -4px;
+  margin-bottom: 12px;
+}
+
+.primary {
+  padding-inline: 20px;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.button {
+  border: none;
+  outline: none;
+  box-shadow: none;
+  background: none;
+  padding: 0;
+  margin: 0;
+  color: var(--accent-links);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 18px;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:disabled {
+    color: var(--text-tertiary);
+    cursor: wait;
+    text-decoration: none;
+  }
+}
+
+.meta {
+  color: var(--text-tertiary);
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 18px;
+}
+
+.translated {
+  margin-top: 10px;
+  padding: 12px;
+  border-radius: 8px;
+  background-color: var(--background-input);
+  color: var(--text-primary);
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 20px;
+}
+
+.error {
+  margin-top: 8px;
+  color: #E20505;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 18px;
+
+  a {
+    color: var(--accent-links);
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/src/components/Note/NoteTranslation.tsx
+++ b/src/components/Note/NoteTranslation.tsx
@@ -1,0 +1,148 @@
+import { Component, Show, createMemo, createSignal } from 'solid-js';
+import { useIntl } from '@cookbook/solid-intl';
+import { PrimalNote } from '../../types/primal';
+import ParsedNote from '../ParsedNote/ParsedNote';
+import { translation as t } from '../../translations';
+import {
+  TranslationResult,
+  hasTranslatableNoteText,
+  isTranslationConfigured,
+  translateNoteContent,
+} from '../../lib/translation';
+import styles from './NoteTranslation.module.scss';
+
+const NoteTranslation: Component<{
+  note: PrimalNote,
+  width?: number,
+  margins?: number,
+  footerSize?: 'xwide' | 'wide' | 'normal' | 'compact' | 'short' | 'mini',
+  primary?: boolean,
+}> = (props) => {
+
+  const intl = useIntl();
+
+  const [loading, setLoading] = createSignal(false);
+  const [showTranslated, setShowTranslated] = createSignal(false);
+  const [result, setResult] = createSignal<TranslationResult>();
+  const [error, setError] = createSignal('');
+
+  const translatable = () => hasTranslatableNoteText(props.note.content || '');
+
+  const translatedNote = createMemo(() => {
+    const translated = result()?.translatedText || props.note.content;
+
+    return {
+      ...props.note,
+      content: translated,
+      post: {
+        ...props.note.post,
+        content: translated,
+      },
+    };
+  });
+
+  const label = () => {
+    if (loading()) return intl.formatMessage(t.translating);
+    if (result() && showTranslated()) return intl.formatMessage(t.showOriginal);
+    if (result()) return intl.formatMessage(t.showTranslation);
+
+    return intl.formatMessage(t.translate);
+  };
+
+  const displayError = () => {
+    const code = error();
+
+    if (code === 'translation_endpoint_missing') {
+      return intl.formatMessage(t.configureProvider);
+    }
+
+    if (code.startsWith('translation_request_failed')) {
+      return intl.formatMessage(t.requestFailed);
+    }
+
+    return intl.formatMessage(t.genericError);
+  };
+
+  const onTranslate = async (event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (result()) {
+      setShowTranslated(show => !show);
+      return;
+    }
+
+    if (!isTranslationConfigured()) {
+      setError('translation_endpoint_missing');
+      return;
+    }
+
+    setLoading(true);
+    setError('');
+
+    try {
+      const translation = await translateNoteContent(props.note.content || '');
+      setResult(translation);
+      setShowTranslated(true);
+    }
+    catch (e) {
+      const message = e instanceof Error ? e.message : 'translation_unknown_error';
+      setError(message);
+    }
+    finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Show when={translatable()}>
+      <div class={`${styles.translation} ${props.primary ? styles.primary : ''}`}>
+        <div class={styles.actions}>
+          <button
+            type="button"
+            class={styles.button}
+            disabled={loading()}
+            onClick={onTranslate}
+          >
+            {label()}
+          </button>
+
+          <Show when={result()?.detectedLanguage && showTranslated()}>
+            <span class={styles.meta}>
+              {intl.formatMessage(t.detectedSource, { language: result()?.detectedLanguage })}
+            </span>
+          </Show>
+
+          <Show when={result()?.fromCache && showTranslated()}>
+            <span class={styles.meta}>
+              {intl.formatMessage(t.fromCache)}
+            </span>
+          </Show>
+        </div>
+
+        <Show when={error()}>
+          <div class={styles.error}>
+            {displayError()} <a href="/settings/translation" onClick={event => event.stopPropagation()}>
+              {intl.formatMessage(t.settingsLink)}
+            </a>
+          </div>
+        </Show>
+
+        <Show when={result() && showTranslated()}>
+          <div class={styles.translated}>
+            <ParsedNote
+              note={translatedNote()}
+              width={props.width}
+              margins={props.margins}
+              footerSize={props.footerSize}
+              noLightbox={true}
+              noPreviews={true}
+            />
+          </div>
+        </Show>
+      </div>
+    </Show>
+  );
+};
+
+export default NoteTranslation;

--- a/src/lib/translation.ts
+++ b/src/lib/translation.ts
@@ -1,0 +1,234 @@
+export type TranslationSettings = {
+  endpoint: string,
+  apiKey: string,
+  targetLanguage: string,
+};
+
+export type TranslationResult = {
+  translatedText: string,
+  detectedLanguage?: string,
+  targetLanguage: string,
+  fromCache: boolean,
+};
+
+type ProtectedToken = {
+  token: string,
+  value: string,
+};
+
+const endpointKey = 'primalTranslationEndpoint';
+const apiKeyKey = 'primalTranslationApiKey';
+const targetLanguageKey = 'primalTranslationTargetLanguage';
+const cachePrefix = 'primalTranslationCache:v1';
+
+export const translationSettingsChanged = 'primalTranslationSettingsChanged';
+
+export const defaultTargetLanguage = () => {
+  if (typeof navigator === 'undefined') return 'en';
+
+  return navigator.language?.split('-')[0]?.toLowerCase() || 'en';
+};
+
+const storage = () => {
+  if (typeof localStorage === 'undefined') return;
+
+  return localStorage;
+};
+
+export const getTranslationSettings = (): TranslationSettings => {
+  const store = storage();
+
+  return {
+    endpoint: store?.getItem(endpointKey)?.trim() || '',
+    apiKey: store?.getItem(apiKeyKey)?.trim() || '',
+    targetLanguage: store?.getItem(targetLanguageKey)?.trim() || defaultTargetLanguage(),
+  };
+};
+
+export const saveTranslationSettings = (settings: TranslationSettings) => {
+  const store = storage();
+  if (!store) return;
+
+  if (settings.endpoint.trim()) {
+    store.setItem(endpointKey, settings.endpoint.trim());
+  }
+  else {
+    store.removeItem(endpointKey);
+  }
+
+  if (settings.apiKey.trim()) {
+    store.setItem(apiKeyKey, settings.apiKey.trim());
+  }
+  else {
+    store.removeItem(apiKeyKey);
+  }
+
+  store.setItem(targetLanguageKey, settings.targetLanguage.trim().toLowerCase() || defaultTargetLanguage());
+  window.dispatchEvent(new CustomEvent(translationSettingsChanged));
+};
+
+export const clearTranslationSettings = () => {
+  const store = storage();
+  if (!store) return;
+
+  store.removeItem(endpointKey);
+  store.removeItem(apiKeyKey);
+  store.removeItem(targetLanguageKey);
+  window.dispatchEvent(new CustomEvent(translationSettingsChanged));
+};
+
+export const isTranslationConfigured = () => getTranslationSettings().endpoint.length > 0;
+
+const hash = (value: string) => {
+  let h1 = 0xdeadbeef;
+  let h2 = 0x41c6ce57;
+
+  for (let i = 0; i < value.length; i++) {
+    const ch = value.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+
+  return `${(h2 >>> 0).toString(36)}${(h1 >>> 0).toString(36)}`;
+};
+
+const cacheKey = (content: string, settings: TranslationSettings) => {
+  const endpoint = settings.endpoint.replace(/\/+$/, '');
+
+  return `${cachePrefix}:${settings.targetLanguage}:${hash(endpoint)}:${hash(content)}`;
+};
+
+const readCachedTranslation = (content: string, settings: TranslationSettings): TranslationResult | undefined => {
+  const store = storage();
+  if (!store) return;
+
+  try {
+    const cached = store.getItem(cacheKey(content, settings));
+    if (!cached) return;
+
+    const parsed = JSON.parse(cached) as TranslationResult;
+    return {
+      ...parsed,
+      fromCache: true,
+    };
+  }
+  catch {
+    return;
+  }
+};
+
+const writeCachedTranslation = (content: string, settings: TranslationSettings, result: TranslationResult) => {
+  const store = storage();
+  if (!store) return;
+
+  try {
+    store.setItem(cacheKey(content, settings), JSON.stringify({
+      ...result,
+      fromCache: false,
+    }));
+  }
+  catch {
+    // A full localStorage cache should not block note translation.
+  }
+};
+
+const protectedPattern = /https?:\/\/[^\s<>()]+|nostr:[a-z0-9]+1[a-z0-9]+|(?:npub|nprofile|note|nevent|naddr)1[a-z0-9]+|#[A-Za-z0-9_]+|@[A-Za-z0-9_.-]+/gi;
+
+const protectContent = (content: string) => {
+  const tokens: ProtectedToken[] = [];
+
+  const text = content.replace(protectedPattern, (value) => {
+    const token = `PRIMALTRANSLATIONTOKEN${tokens.length}END`;
+    tokens.push({ token, value });
+    return token;
+  });
+
+  return { text, tokens };
+};
+
+const restoreContent = (content: string, tokens: ProtectedToken[]) => {
+  return tokens.reduce((translated, item) => {
+    return translated.replaceAll(item.token, item.value);
+  }, content);
+};
+
+export const hasTranslatableNoteText = (content: string) => {
+  const protectedText = protectContent(content).text;
+  const textOnly = protectedText.replace(/PRIMALTRANSLATIONTOKEN\d+END/g, '').trim();
+
+  return /[A-Za-zÀ-ž]/.test(textOnly);
+};
+
+const detectedLanguage = (data: Record<string, any>) => {
+  const detected = data.detectedLanguage || data.detected_language || data.detected_source_language;
+
+  if (typeof detected === 'string') return detected;
+  if (typeof detected?.language === 'string') return detected.language;
+  if (typeof detected?.confidence === 'number' && typeof detected?.lang === 'string') return detected.lang;
+
+  return undefined;
+};
+
+export const translateNoteContent = async (
+  content: string,
+  settings = getTranslationSettings(),
+): Promise<TranslationResult> => {
+  if (!settings.endpoint) {
+    throw new Error('translation_endpoint_missing');
+  }
+
+  const targetLanguage = settings.targetLanguage || defaultTargetLanguage();
+  const normalizedSettings = {
+    ...settings,
+    targetLanguage,
+  };
+
+  const cached = readCachedTranslation(content, normalizedSettings);
+  if (cached) return cached;
+
+  const { text, tokens } = protectContent(content);
+
+  const body: Record<string, string> = {
+    q: text,
+    source: 'auto',
+    target: targetLanguage,
+    format: 'text',
+  };
+
+  if (settings.apiKey) {
+    body.api_key = settings.apiKey;
+  }
+
+  const response = await fetch(settings.endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(`translation_request_failed:${response.status}`);
+  }
+
+  const data = await response.json();
+  const translated = data.translatedText || data.translation || data.text;
+
+  if (typeof translated !== 'string' || translated.length === 0) {
+    throw new Error('translation_response_invalid');
+  }
+
+  const result: TranslationResult = {
+    translatedText: restoreContent(translated, tokens),
+    detectedLanguage: detectedLanguage(data),
+    targetLanguage,
+    fromCache: false,
+  };
+
+  writeCachedTranslation(content, normalizedSettings, result);
+
+  return result;
+};

--- a/src/pages/Settings/Menu.tsx
+++ b/src/pages/Settings/Menu.tsx
@@ -83,6 +83,11 @@ const Menu: Component = () => {
           <div class={styles.chevron}></div>
         </A>
 
+        <A href="/settings/translation">
+          {intl.formatMessage(t.translation.title)}
+          <div class={styles.chevron}></div>
+        </A>
+
         <Show when={hasPublicKey()}>
           <A href="/settings/zaps">
             {intl.formatMessage(t.zaps)}

--- a/src/pages/Settings/Translation.tsx
+++ b/src/pages/Settings/Translation.tsx
@@ -1,0 +1,172 @@
+import { A } from '@solidjs/router';
+import { Component, Show, createSignal } from 'solid-js';
+import { useIntl } from '@cookbook/solid-intl';
+import PageCaption from '../../components/PageCaption/PageCaption';
+import PageTitle from '../../components/PageTitle/PageTitle';
+import ButtonPrimary from '../../components/Buttons/ButtonPrimary';
+import ButtonLink from '../../components/Buttons/ButtonLink';
+import { actions as tActions, settings as tSettings } from '../../translations';
+import {
+  clearTranslationSettings,
+  defaultTargetLanguage,
+  getTranslationSettings,
+  saveTranslationSettings,
+} from '../../lib/translation';
+import styles from './Settings.module.scss';
+
+const Translation: Component = () => {
+
+  const intl = useIntl();
+  const initial = getTranslationSettings();
+
+  const [endpoint, setEndpoint] = createSignal(initial.endpoint);
+  const [apiKey, setApiKey] = createSignal(initial.apiKey);
+  const [targetLanguage, setTargetLanguage] = createSignal(initial.targetLanguage || defaultTargetLanguage());
+  const [invalidEndpoint, setInvalidEndpoint] = createSignal(false);
+  const [saved, setSaved] = createSignal(false);
+
+  const validateEndpoint = () => {
+    const value = endpoint().trim();
+
+    if (!value) return true;
+
+    try {
+      const url = new URL(value);
+      return ['https:', 'http:'].includes(url.protocol);
+    }
+    catch {
+      return false;
+    }
+  };
+
+  const save = () => {
+    if (!validateEndpoint()) {
+      setInvalidEndpoint(true);
+      setSaved(false);
+      return;
+    }
+
+    saveTranslationSettings({
+      endpoint: endpoint(),
+      apiKey: apiKey(),
+      targetLanguage: targetLanguage(),
+    });
+    setInvalidEndpoint(false);
+    setSaved(true);
+  };
+
+  const clear = () => {
+    clearTranslationSettings();
+    setEndpoint('');
+    setApiKey('');
+    setTargetLanguage(defaultTargetLanguage());
+    setInvalidEndpoint(false);
+    setSaved(false);
+  };
+
+  return (
+    <div>
+      <PageTitle title={`${intl.formatMessage(tSettings.translation.title)} ${intl.formatMessage(tSettings.title)}`} />
+
+      <PageCaption>
+        <A href='/settings'>{intl.formatMessage(tSettings.index.title)}</A>:&nbsp;
+        <div>{intl.formatMessage(tSettings.translation.title)}</div>
+      </PageCaption>
+
+      <div class={styles.settingsContent}>
+        <div class={styles.bigCaption}>
+          {intl.formatMessage(tSettings.translation.provider)}
+        </div>
+
+        <div class={styles.settingsDescription}>
+          {intl.formatMessage(tSettings.translation.description)}
+        </div>
+
+        <div style="height: 20px"></div>
+
+        <div class={styles.settingsCaption}>
+          {intl.formatMessage(tSettings.translation.endpoint)}
+        </div>
+
+        <div class={styles.nwcInput}>
+          <input
+            class="large"
+            type="text"
+            value={endpoint()}
+            placeholder={intl.formatMessage(tSettings.translation.endpointPlaceholder)}
+            onInput={event => {
+              setEndpoint(event.currentTarget.value);
+              setInvalidEndpoint(false);
+              setSaved(false);
+            }}
+          />
+        </div>
+
+        <Show when={invalidEndpoint()}>
+          <div class={styles.invalidInput}>
+            {intl.formatMessage(tSettings.translation.invalidEndpoint)}
+          </div>
+        </Show>
+
+        <div style="height: 24px"></div>
+
+        <div class={styles.settingsCaption}>
+          {intl.formatMessage(tSettings.translation.apiKey)}
+        </div>
+
+        <div class={styles.nwcInput}>
+          <input
+            class="large"
+            type="password"
+            value={apiKey()}
+            placeholder={intl.formatMessage(tSettings.translation.apiKeyPlaceholder)}
+            onInput={event => {
+              setApiKey(event.currentTarget.value);
+              setSaved(false);
+            }}
+          />
+        </div>
+
+        <div style="height: 24px"></div>
+
+        <div class={styles.settingsCaption}>
+          {intl.formatMessage(tSettings.translation.targetLanguage)}
+        </div>
+
+        <div class={styles.nwcInput}>
+          <input
+            class="large"
+            type="text"
+            value={targetLanguage()}
+            placeholder={defaultTargetLanguage()}
+            maxlength={8}
+            onInput={event => {
+              setTargetLanguage(event.currentTarget.value);
+              setSaved(false);
+            }}
+          />
+        </div>
+
+        <Show when={saved()}>
+          <div class={styles.settingsDescription}>
+            {intl.formatMessage(tSettings.translation.saved)}
+          </div>
+        </Show>
+
+        <div style="height: 24px"></div>
+
+        <ButtonPrimary onClick={save}>
+          {intl.formatMessage(tActions.save)}
+        </ButtonPrimary>
+
+        <div style="height: 16px"></div>
+
+        <ButtonLink onClick={clear}>
+          {intl.formatMessage(tSettings.translation.clear)}
+        </ButtonLink>
+      </div>
+    </div>
+  );
+};
+
+export default Translation;

--- a/src/translations.ts
+++ b/src/translations.ts
@@ -1782,6 +1782,59 @@ export const eventQueue = {
   },
 }
 
+export const translation = {
+  translate: {
+    id: 'translation.translate',
+    defaultMessage: 'Translate',
+    description: 'Button label for translating a note',
+  },
+  translating: {
+    id: 'translation.translating',
+    defaultMessage: 'Translating...',
+    description: 'Button label while a note translation is loading',
+  },
+  showTranslation: {
+    id: 'translation.showTranslation',
+    defaultMessage: 'Show translation',
+    description: 'Button label for showing a cached note translation',
+  },
+  showOriginal: {
+    id: 'translation.showOriginal',
+    defaultMessage: 'Show original',
+    description: 'Button label for hiding an inline note translation',
+  },
+  detectedSource: {
+    id: 'translation.detectedSource',
+    defaultMessage: 'Translated from {language}',
+    description: 'Label showing the detected source language',
+  },
+  fromCache: {
+    id: 'translation.fromCache',
+    defaultMessage: 'cached',
+    description: 'Label indicating a translation came from local cache',
+  },
+  configureProvider: {
+    id: 'translation.configureProvider',
+    defaultMessage: 'Configure a translation provider to translate notes.',
+    description: 'Message shown when translation provider settings are missing',
+  },
+  requestFailed: {
+    id: 'translation.requestFailed',
+    defaultMessage: 'Translation failed. Please try again later.',
+    description: 'Message shown when a translation request fails',
+  },
+  genericError: {
+    id: 'translation.genericError',
+    defaultMessage: 'Unable to translate this note.',
+    description: 'Generic translation error message',
+  },
+  settingsLink: {
+    id: 'translation.settingsLink',
+    defaultMessage: 'Translation settings',
+    description: 'Link label to translation settings',
+  },
+};
+
 export const settings = {
   index: {
     title: {
@@ -1856,6 +1909,63 @@ export const settings = {
       id: 'settings.readsFeeds.caption',
       defaultMessage: 'Edit and order your reads page feeds',
       description: 'Caption for reads feed ordering',
+    },
+  },
+  translation: {
+    title: {
+      id: 'settings.translation.title',
+      defaultMessage: 'Translation',
+      description: 'Title of the translation settings sub-page',
+    },
+    provider: {
+      id: 'settings.translation.provider',
+      defaultMessage: 'Translation Provider',
+      description: 'Title of the translation provider settings section',
+    },
+    description: {
+      id: 'settings.translation.description',
+      defaultMessage: 'Primal can translate note text inline by calling a documented LibreTranslate-compatible endpoint. URLs, Nostr references, hashtags, and mentions are protected before the request and restored afterward.',
+      description: 'Description of translation provider settings',
+    },
+    endpoint: {
+      id: 'settings.translation.endpoint',
+      defaultMessage: 'Endpoint URL',
+      description: 'Label for translation endpoint input',
+    },
+    endpointPlaceholder: {
+      id: 'settings.translation.endpointPlaceholder',
+      defaultMessage: 'https://libretranslate.example/translate',
+      description: 'Placeholder for translation endpoint input',
+    },
+    apiKey: {
+      id: 'settings.translation.apiKey',
+      defaultMessage: 'API key',
+      description: 'Label for translation API key input',
+    },
+    apiKeyPlaceholder: {
+      id: 'settings.translation.apiKeyPlaceholder',
+      defaultMessage: 'Optional',
+      description: 'Placeholder for translation API key input',
+    },
+    targetLanguage: {
+      id: 'settings.translation.targetLanguage',
+      defaultMessage: 'Target language',
+      description: 'Label for translation target language input',
+    },
+    invalidEndpoint: {
+      id: 'settings.translation.invalidEndpoint',
+      defaultMessage: 'Enter a valid HTTP or HTTPS endpoint.',
+      description: 'Error shown for invalid translation endpoint',
+    },
+    saved: {
+      id: 'settings.translation.saved',
+      defaultMessage: 'Translation settings saved.',
+      description: 'Message shown after translation settings are saved',
+    },
+    clear: {
+      id: 'settings.translation.clear',
+      defaultMessage: 'Clear translation settings',
+      description: 'Label for clearing translation settings',
     },
   },
   moderation: {


### PR DESCRIPTION
Addresses #133.

## Summary

- add an inline Translate action below note content in primary, feed, thread, and suggestion note layouts
- add `/settings/translation` for a LibreTranslate-compatible endpoint, optional API key, and target language
- cache translations in `localStorage` by endpoint, target language, and note content hash
- protect URLs, Nostr references, hashtags, and mentions before the translation request and restore them afterward
- show detected source language when returned by the provider, support show original/show translation toggling, and fail gracefully when the provider is missing or unavailable

The implementation does not call any translation provider automatically. Users only send content after clicking Translate, which keeps cost and privacy behavior explicit.

## Verification

- `npm run build`
