### PR TITLE
Add note translation support

### DIFF
--- a/src/components/Note/Note.module.scss
+++ b/src/components/Note/Note.module.scss
@@ -128,6 +128,59 @@
   right: -10px;
 }
 
+.translationWrapper {
+  width: 100%;
+}
+
+.translationControls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 18px;
+}
+
+.translateButton {
+  width: fit-content;
+  margin: 0;
+  padding: 0;
+  border: none;
+  outline: none;
+  background: none;
+  color: var(--accent-links);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 18px;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:disabled {
+    color: var(--text-tertiary);
+    cursor: default;
+    text-decoration: none;
+  }
+}
+
+.translationMeta {
+  margin-top: 8px;
+  color: var(--text-tertiary);
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 18px;
+}
+
+.translationError {
+  color: var(--text-tertiary);
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 18px;
+}
+
 .noteThread {
   position: relative;
   display: flex;

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -23,6 +23,7 @@ import { addrRegexG, imageRegexG, linebreakRegex, noteRegex, urlRegexG } from '.
 import { TranslatorProvider } from '../../contexts/TranslatorContext';
 import { accountStore } from '../../stores/accountStore';
 import { useNavigate } from '@solidjs/router';
+import NoteTranslation from './NoteTranslation';
 
 export type NoteReactionsState = {
   bookmarks?: number,
@@ -407,7 +408,7 @@ const Note: Component<NoteProps> = (props) => {
           <div class={styles.content}>
 
             <div class={`${styles.message} ${bigMessageFont() ? styles.bigFont : ''}`}>
-              <ParsedNote
+              <NoteTranslation
                 note={props.note}
                 width={Math.min(598, window.innerWidth)}
                 margins={isPhone() ? 42 : 1}
@@ -549,7 +550,7 @@ const Note: Component<NoteProps> = (props) => {
             // href={!props.onClick ? noteLinkId() : ''}
             onClick={() => navToThread(props.note)}
           >
-            <ParsedNote
+            <NoteTranslation
               note={props.note}
               shorten={props.shorten}
               width={window.innerWidth}
@@ -635,7 +636,7 @@ const Note: Component<NoteProps> = (props) => {
                   navToThread(props.note)
                 }}
               >
-                <ParsedNote
+                <NoteTranslation
                   note={props.note}
                   shorten={props.shorten}
                   width={Math.min(510, window.innerWidth - 72)}

--- a/src/components/Note/NoteTranslation.tsx
+++ b/src/components/Note/NoteTranslation.tsx
@@ -1,0 +1,153 @@
+import { useIntl } from '@cookbook/solid-intl';
+import { Component, Show, createSignal } from 'solid-js';
+import { useSettingsContext } from '../../contexts/SettingsContext';
+import { canTranslateNote, normalizeTranslationLanguage, translateNote } from '../../lib/translate';
+import { note as t } from '../../translations';
+import { NoteTranslationResponse, PrimalNote } from '../../types/primal';
+import ParsedNote from '../ParsedNote/ParsedNote';
+
+import styles from './Note.module.scss';
+
+const languageName = (language: string | undefined, locale: string) => {
+  if (!language) return '';
+
+  try {
+    const DisplayNames = (Intl as any).DisplayNames;
+
+    if (!DisplayNames) return language;
+
+    const names = new DisplayNames([locale], { type: 'language' });
+    return names.of(language) || language;
+  } catch {
+    return language;
+  }
+};
+
+const NoteTranslation: Component<{
+  note: PrimalNote,
+  id?: string,
+  shorten?: boolean,
+  width?: number,
+  margins?: number,
+  footerSize?: 'xwide' | 'wide' | 'normal' | 'compact' | 'short' | 'mini',
+}> = (props) => {
+
+  const intl = useIntl();
+  const settings = useSettingsContext();
+
+  const [status, setStatus] = createSignal<'idle' | 'loading' | 'ready' | 'error'>('idle');
+  const [showOriginal, setShowOriginal] = createSignal(true);
+  const [translation, setTranslation] = createSignal<NoteTranslationResponse>();
+
+  const targetLanguage = () => normalizeTranslationLanguage(settings?.locale);
+
+  const translatedFrom = () => {
+    const source = translation()?.detectedSourceLanguage;
+
+    if (!source) return '';
+
+    return intl.formatMessage(t.translatedFrom, {
+      language: languageName(source, targetLanguage()),
+    });
+  };
+
+  const buttonLabel = () => {
+    if (status() === 'loading') return intl.formatMessage(t.translating);
+
+    if (translation()) {
+      return showOriginal() ?
+        intl.formatMessage(t.showTranslation) :
+        intl.formatMessage(t.showOriginal);
+    }
+
+    return intl.formatMessage(t.translate);
+  };
+
+  const onTranslate = async (e: MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (status() === 'loading') return;
+
+    if (translation()) {
+      setShowOriginal(show => !show);
+      return;
+    }
+
+    try {
+      setStatus('loading');
+
+      const response = await translateNote(props.note, targetLanguage());
+
+      setTranslation(() => response);
+      setShowOriginal(false);
+      setStatus('ready');
+    } catch {
+      setStatus('error');
+      setShowOriginal(true);
+    }
+  };
+
+  return (
+    <div class={styles.translationWrapper}>
+      <Show
+        when={!showOriginal() && translation()}
+        fallback={
+          <ParsedNote
+            note={props.note}
+            id={props.id}
+            shorten={props.shorten}
+            width={props.width}
+            margins={props.margins}
+            footerSize={props.footerSize}
+          />
+        }
+      >
+        {(translated) => (
+          <>
+            <ParsedNote
+              note={props.note}
+              id={`translated_${props.note.noteId}`}
+              contentOverride={translated().translatedText}
+              shorten={props.shorten}
+              width={props.width}
+              margins={props.margins}
+              footerSize={props.footerSize}
+              ignoreMedia={true}
+              noPreviews={true}
+            />
+
+            <Show when={translatedFrom()}>
+              <div class={styles.translationMeta}>
+                {translatedFrom()}
+              </div>
+            </Show>
+          </>
+        )}
+      </Show>
+
+      <Show when={canTranslateNote(props.note)}>
+        <div class={styles.translationControls}>
+          <button
+            type="button"
+            class={styles.translateButton}
+            onClick={onTranslate}
+            disabled={status() === 'loading'}
+            aria-busy={status() === 'loading'}
+            aria-pressed={!showOriginal()}
+          >
+            {buttonLabel()}
+          </button>
+
+          <Show when={status() === 'error'}>
+            <span class={styles.translationError}>
+              {intl.formatMessage(t.translationUnavailable)}
+            </span>
+          </Show>
+        </div>
+      </Show>
+    </div>
+  );
+};
+
+export default NoteTranslation;

--- a/src/components/ParsedNote/ParsedNote.tsx
+++ b/src/components/ParsedNote/ParsedNote.tsx
@@ -196,6 +196,7 @@ const ParsedNote: Component<{
   rootNote?: PrimalNote,
   noPlaceholders?: boolean,
   footerSize?: 'xwide' | 'wide' | 'normal' | 'compact' | 'short' | 'mini',
+  contentOverride?: string,
 }> = (props) => {
 
   const intl = useIntl();
@@ -205,7 +206,7 @@ const ParsedNote: Component<{
   const dev = localStorage.getItem('devMode') === 'true';
 
   const id = () => {
-    // if (props.id) return props.id;
+    if (props.id) return props.id;
 
     return `note_${props.note.noteId}`;
   }
@@ -242,7 +243,7 @@ const ParsedNote: Component<{
   const rootNote = () => props.rootNote || props.note;
 
   const noteContent = () => {
-    const content = props.note.content || '';
+    const content = props.contentOverride ?? props.note.content ?? '';
     const charLimit = 7 * shortNoteChars;
 
     if (!props.shorten || content.length < charLimit) return content;
@@ -2088,7 +2089,7 @@ const ParsedNote: Component<{
       <For each={content}>
         {(item, index) => renderContent(item, index(), content.length)}
       </For>
-      <Show when={isNoteTooLong() || noteContent().length < (props.note.content?.length || 0)}>
+      <Show when={isNoteTooLong() || noteContent().length < ((props.contentOverride ?? props.note.content)?.length || 0)}>
         <span class={styles.more}>
           ... <span class="linkish">{intl.formatMessage(actions.seeMore)}</span>
         </span>

--- a/src/lib/translate.ts
+++ b/src/lib/translate.ts
@@ -1,0 +1,329 @@
+import { APP_ID } from "../App";
+import {
+  addrRegexG,
+  hashtagRegex,
+  lnRegex,
+  lnUnifiedRegex,
+  noteRegex,
+  tagMentionRegex,
+  urlRegexG,
+} from "../constants";
+import { sendMessage, subsTo } from "../sockets";
+import {
+  NoteTranslationCacheEntry,
+  NoteTranslationRequestPayload,
+  NoteTranslationResponse,
+  NoteTranslationStoredResponse,
+  NostrEventContent,
+  PrimalNote,
+} from "../types/primal";
+import { getLang, sha256Text, uuidv4 } from "../utils";
+
+const CACHE_STORAGE_KEY = 'note_translation_cache_v1';
+const MAX_CACHE_ENTRIES = 200;
+const TRANSLATION_TIMEOUT = 15_000;
+const TOKEN_PREFIX = '__PRIMAL_TRANSLATION_TOKEN_';
+const TOKEN_SUFFIX = '__';
+
+type ProtectedEntity = {
+  placeholder: string,
+  value: string,
+};
+
+type PreparedTranslationText = {
+  contentHash: string,
+  text: string,
+  protectedEntities: ProtectedEntity[],
+  hasTranslatableText: boolean,
+};
+
+const pendingRequests: Record<string, Promise<NoteTranslationResponse>> = {};
+
+const protectMatches = (
+  text: string,
+  regex: RegExp,
+  entities: ProtectedEntity[],
+  transform?: (match: string) => { prefix?: string, value: string },
+) => {
+  regex.lastIndex = 0;
+
+  return text.replace(regex, (match: string) => {
+    const entity = transform ? transform(match) : { value: match };
+    const placeholder = `${TOKEN_PREFIX}${entities.length}${TOKEN_SUFFIX}`;
+
+    entities.push({
+      placeholder,
+      value: entity.value,
+    });
+
+    return `${entity.prefix || ''}${placeholder}`;
+  });
+};
+
+const getTextWithoutProtectedEntities = (text: string) => {
+  return text
+    .replace(new RegExp(`${TOKEN_PREFIX}\\d+${TOKEN_SUFFIX}`, 'g'), ' ')
+    .trim();
+};
+
+const hasTranslatableText = (text: string) => /[\p{L}\p{N}]/u.test(text);
+
+const protectNoteContent = (content: string) => {
+  const protectedEntities: ProtectedEntity[] = [];
+  let text = content;
+
+  text = protectMatches(text, urlRegexG, protectedEntities);
+  text = protectMatches(text, /nostr:((note|nevent|npub|nprofile|naddr)1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]+)\b/ig, protectedEntities);
+  text = protectMatches(text, noteRegex, protectedEntities);
+  text = protectMatches(text, addrRegexG, protectedEntities);
+  text = protectMatches(text, /((npub|nprofile)1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]+)\b/ig, protectedEntities);
+  text = protectMatches(text, new RegExp(tagMentionRegex.source, 'g'), protectedEntities);
+  text = protectMatches(text, new RegExp(lnUnifiedRegex.source, 'ig'), protectedEntities);
+  text = protectMatches(text, new RegExp(lnRegex.source, 'ig'), protectedEntities);
+  text = protectMatches(
+    text,
+    new RegExp(hashtagRegex.source, 'ig'),
+    protectedEntities,
+    (match) => {
+      const prefix = match.match(/^\s/)?.[0] || '';
+      return {
+        prefix,
+        value: match.slice(prefix.length),
+      };
+    },
+  );
+
+  return {
+    text,
+    protectedEntities,
+  };
+};
+
+export const restoreProtectedEntities = (text: string, protectedEntities: ProtectedEntity[]) => {
+  return protectedEntities.reduce((translated, entity) => {
+    return translated.replaceAll(entity.placeholder, entity.value);
+  }, text);
+};
+
+export const prepareNoteForTranslation = async (note: PrimalNote): Promise<PreparedTranslationText> => {
+  const protectedContent = protectNoteContent(note.content || '');
+  const textWithoutProtectedEntities = getTextWithoutProtectedEntities(protectedContent.text);
+
+  return {
+    contentHash: await sha256Text(note.content || ''),
+    text: protectedContent.text,
+    protectedEntities: protectedContent.protectedEntities,
+    hasTranslatableText: hasTranslatableText(textWithoutProtectedEntities),
+  };
+};
+
+export const normalizeTranslationLanguage = (locale?: string) => {
+  return (locale || getLang() || 'en').trim();
+};
+
+export const getTranslationCacheKey = (contentHash: string, targetLanguage: string) => {
+  return `${targetLanguage.toLowerCase()}:${contentHash}`;
+};
+
+const readTranslationCache = (): Record<string, NoteTranslationCacheEntry> => {
+  try {
+    return JSON.parse(localStorage.getItem(CACHE_STORAGE_KEY) || '{}');
+  } catch {
+    return {};
+  }
+};
+
+const writeTranslationCache = (cache: Record<string, NoteTranslationCacheEntry>) => {
+  const entries = Object.entries(cache)
+    .sort(([, a], [, b]) => b.createdAt - a.createdAt)
+    .slice(0, MAX_CACHE_ENTRIES);
+
+  localStorage.setItem(CACHE_STORAGE_KEY, JSON.stringify(Object.fromEntries(entries)));
+};
+
+const readCachedTranslation = (cacheKey: string): NoteTranslationStoredResponse | undefined => {
+  return readTranslationCache()[cacheKey]?.response;
+};
+
+const saveCachedTranslation = (cacheKey: string, response: NoteTranslationStoredResponse) => {
+  const cache = readTranslationCache();
+
+  cache[cacheKey] = {
+    createdAt: Date.now(),
+    response,
+  };
+
+  writeTranslationCache(cache);
+};
+
+const parseTranslationResponse = (
+  content: NostrEventContent | undefined,
+  targetLanguage: string,
+  protectedEntities: ProtectedEntity[],
+): NoteTranslationStoredResponse => {
+  if (!content?.content) {
+    throw new Error('empty_translation_response');
+  }
+
+  let payload: Record<string, any> | string = content.content;
+
+  try {
+    payload = JSON.parse(content.content);
+  } catch {
+    payload = content.content;
+  }
+
+  if (typeof payload === 'string') {
+    return {
+      translatedText: restoreProtectedEntities(payload, protectedEntities),
+      targetLanguage,
+    };
+  }
+
+  if (payload.error) {
+    throw new Error(`${payload.error}`);
+  }
+
+  const translatedText = payload.translated_text ||
+    payload.translatedText ||
+    payload.translation ||
+    payload.text ||
+    '';
+
+  if (!translatedText || typeof translatedText !== 'string') {
+    throw new Error('empty_translation_text');
+  }
+
+  return {
+    translatedText: restoreProtectedEntities(translatedText, protectedEntities),
+    detectedSourceLanguage: payload.detected_source_language ||
+      payload.detectedSourceLanguage ||
+      payload.source_language ||
+      payload.sourceLanguage,
+    targetLanguage: payload.target_language ||
+      payload.targetLanguage ||
+      targetLanguage,
+    provider: payload.provider,
+    cached: payload.cached,
+  };
+};
+
+const requestTranslation = (
+  payload: NoteTranslationRequestPayload,
+  protectedEntities: ProtectedEntity[],
+): Promise<NoteTranslationStoredResponse> => {
+  const subId = `translate_note_${APP_ID}_${uuidv4()}`;
+
+  return new Promise((resolve, reject) => {
+    let done = false;
+
+    const cleanup = (unsub: () => void, timeout: number) => {
+      done = true;
+      window.clearTimeout(timeout);
+      unsub();
+    };
+
+    const unsub = subsTo(subId, {
+      onEvent: (_, content) => {
+        if (done) return;
+
+        try {
+          const response = parseTranslationResponse(
+            content,
+            payload.target_language,
+            protectedEntities,
+          );
+
+          cleanup(unsub, timeout);
+          resolve(response);
+        } catch (e) {
+          cleanup(unsub, timeout);
+          reject(e);
+        }
+      },
+      onNotice: (_, reason) => {
+        if (done) return;
+
+        cleanup(unsub, timeout);
+        reject(new Error(reason || 'translation_unavailable'));
+      },
+    });
+
+    const timeout = window.setTimeout(() => {
+      if (done) return;
+
+      cleanup(unsub, timeout);
+      reject(new Error('translation_timeout'));
+    }, TRANSLATION_TIMEOUT);
+
+    sendMessage(JSON.stringify([
+      'REQ',
+      subId,
+      {
+        cache: [
+          'translate_note',
+          payload,
+        ],
+      },
+    ]));
+  });
+};
+
+export const translateNote = async (
+  note: PrimalNote,
+  targetLanguage: string,
+): Promise<NoteTranslationResponse> => {
+  const prepared = await prepareNoteForTranslation(note);
+
+  if (!prepared.hasTranslatableText) {
+    throw new Error('no_translatable_text');
+  }
+
+  const normalizedTargetLanguage = normalizeTranslationLanguage(targetLanguage);
+  const cacheKey = getTranslationCacheKey(prepared.contentHash, normalizedTargetLanguage);
+  const cachedResponse = readCachedTranslation(cacheKey);
+
+  if (cachedResponse) {
+    return {
+      ...cachedResponse,
+      cacheKey,
+      contentHash: prepared.contentHash,
+      cached: true,
+    };
+  }
+
+  if (pendingRequests[cacheKey]) {
+    return pendingRequests[cacheKey];
+  }
+
+  const payload: NoteTranslationRequestPayload = {
+    event_id: note.id,
+    content_hash: prepared.contentHash,
+    text: prepared.text,
+    target_language: normalizedTargetLanguage,
+    protected_entities: prepared.protectedEntities,
+  };
+
+  pendingRequests[cacheKey] = requestTranslation(payload, prepared.protectedEntities)
+    .then((response) => {
+      saveCachedTranslation(cacheKey, response);
+
+      return {
+        ...response,
+        cacheKey,
+        contentHash: prepared.contentHash,
+      };
+    })
+    .finally(() => {
+      delete pendingRequests[cacheKey];
+    });
+
+  return pendingRequests[cacheKey];
+};
+
+export const canTranslateNote = (note: PrimalNote) => {
+  const protectedContent = protectNoteContent(note.content || '');
+  const textWithoutProtectedEntities = getTextWithoutProtectedEntities(protectedContent.text);
+
+  return hasTranslatableText(textWithoutProtectedEntities);
+};

--- a/src/translations.ts
+++ b/src/translations.ts
@@ -1103,6 +1103,36 @@ export const note = {
     defaultMessage: 'replying to',
     description: 'Label indicating that the note is a reply',
   },
+  translate: {
+    id: 'note.translate',
+    defaultMessage: 'Translate',
+    description: 'Button label for translating a note',
+  },
+  translating: {
+    id: 'note.translating',
+    defaultMessage: 'Translating...',
+    description: 'Button label shown while a note is being translated',
+  },
+  showOriginal: {
+    id: 'note.showOriginal',
+    defaultMessage: 'Show original',
+    description: 'Button label for switching a translated note back to original text',
+  },
+  showTranslation: {
+    id: 'note.showTranslation',
+    defaultMessage: 'Show translation',
+    description: 'Button label for switching a note back to translated text',
+  },
+  translatedFrom: {
+    id: 'note.translatedFrom',
+    defaultMessage: 'Translated from {language}',
+    description: 'Label indicating the detected source language of a translated note',
+  },
+  translationUnavailable: {
+    id: 'note.translationUnavailable',
+    defaultMessage: 'Translation unavailable',
+    description: 'Inline error shown when translating a note fails',
+  },
   saveNoteDraft: {
     title: {
       id: 'note.saveNoteDraft.title',

--- a/src/types/primal.d.ts
+++ b/src/types/primal.d.ts
@@ -644,6 +644,37 @@ export type NoteActions = {
   voted_for_option?: string,
 };
 
+export type NoteTranslationProtectedEntity = {
+  placeholder: string,
+  value: string,
+};
+
+export type NoteTranslationRequestPayload = {
+  event_id: string,
+  content_hash: string,
+  text: string,
+  target_language: string,
+  protected_entities: NoteTranslationProtectedEntity[],
+};
+
+export type NoteTranslationStoredResponse = {
+  translatedText: string,
+  detectedSourceLanguage?: string,
+  targetLanguage: string,
+  provider?: string,
+  cached?: boolean,
+};
+
+export type NoteTranslationResponse = NoteTranslationStoredResponse & {
+  cacheKey: string,
+  contentHash: string,
+};
+
+export type NoteTranslationCacheEntry = {
+  createdAt: number,
+  response: NoteTranslationStoredResponse,
+};
+
 export type FeedStore = {
   posts: PrimalNote[],
   isFetching: boolean,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -143,6 +143,18 @@ export const sha256 = async (file: File) => {
   });
 }
 
+export const sha256Text = async (text: string) => {
+  const obj = new TextEncoder().encode(text);
+
+  return crypto.subtle.digest('SHA-256', obj).then((hashBuffer) => {
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    const hashHex = hashArray
+      .map((bytes) => bytes.toString(16).padStart(2, '0'))
+      .join('');
+    return hashHex;
+  });
+}
+
 export const convertHtmlEntityToAngleBrackets = (fieldText: string) => {
   const htmlEntities = /&(lt|gt);/
   const isHtmlEntityUsed = htmlEntities.test(fieldText)


### PR DESCRIPTION
## Summary

Adds the frontend side of inline note translation, following the direction from issue https://github.com/PrimalHQ/primal-web-app/issues/133.

This implements an X/Twitter-style translation flow inside full note cards:

- Shows a `Translate` button below note content
- Displays translated text inline
- Toggles between translated text and the original note
- Shows detected source language when returned by the backend
- Fails gracefully when the translation service is unavailable

## Important Backend Dependency

This PR does **not** call Google Translate or Google Cloud Translation directly from the browser.

Instead, it expects Primal’s cache/backend service to expose a reliable translation endpoint.

Request shape:

```ts
cache: [
  "translate_note",
  {
    event_id,
    content_hash,
    text,
    target_language,
    protected_entities
  }
]
```

Expected response shape:

```ts
{
  translated_text: string,
  detected_source_language?: string,
  target_language: string,
  provider?: string,
  cached?: boolean
}
```

Until that backend endpoint exists and is deployed, the UI will show `Translation unavailable`, which is the intended graceful failure state.

## What Changed

- Added a `NoteTranslation` wrapper component for full note layouts
- Added a translation client helper in `src/lib/translate.ts`
- Added client-side translation caching keyed by `target_language:content_hash`
- Added text hashing helper for note content
- Added protection and restoration for Nostr-specific entities before translation
- Added `contentOverride` support to `ParsedNote`
- Added translation UI strings through the app i18n system
- Added loading, toggle, source-language, and failure UI states

## Protected Entities

The translation preparation step protects these entities before sending note text for translation:

- `nostr:` references
- `npub`
- `nprofile`
- `note`
- `nevent`
- `naddr`
- `#[n]` tag references
- URLs
- Hashtags
- Lightning invoices
- Unified lightning URIs

This prevents translation providers from mangling Nostr references, links, hashtags, and payment strings.

## Files Changed

- `src/components/Note/NoteTranslation.tsx`
- `src/lib/translate.ts`
- `src/components/Note/Note.tsx`
- `src/components/ParsedNote/ParsedNote.tsx`
- `src/components/Note/Note.module.scss`
- `src/translations.ts`
- `src/types/primal.d.ts`
- `src/utils.ts`

## Notes

This PR intentionally keeps provider credentials and translation-service calls out of the frontend.

A backend implementation can use Google Cloud Translation or another reliable provider without exposing credentials to users.

## Testing

- [x] Ran `npm run build`
- [x] Ran `git diff --check`
- [x] Started local dev server
- [x] Smoke checked app at `http://127.0.0.1:5173/index.html`
- [x] Verified graceful failure state when backend endpoint is unavailable

## Follow-Up Needed

Before this is marked ready for merge, maintainers should confirm:

- Exact `translate_note` cache endpoint contract
- Whether translation should be Premium-gated
- Target language source:
  - current app locale
  - browser language
  - future explicit user setting
- Whether companion backend work should live in `PrimalHQ/primal-server`