### PR TITLE
Add configurable note translation (settings-driven providers, sanitized content, cached)

### DIFF
--- a/scripts/check-translation-sanitize.ts
+++ b/scripts/check-translation-sanitize.ts
@@ -1,0 +1,11 @@
+import { restoreTranslationContent, sanitizeForTranslation } from '../src/lib/translationSanitizer.ts';
+
+const original = 'Hi nostr:npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq visit https://example.com/a #nostr :party_parrot:';
+const sanitized = sanitizeForTranslation(original);
+const restored = restoreTranslationContent(sanitized.content, sanitized.placeholders);
+
+if (restored !== original || /nostr:|https?:\/\/|#nostr|:party_parrot:/.test(sanitized.content)) {
+  throw new Error('Translation sanitization round-trip failed');
+}
+
+console.log('translation sanitize round-trip: PASS');

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -43,6 +43,7 @@ const Premiums = lazy(() => import('./pages/Premium/Premiums'));
 const NotifSettings = lazy(() => import('./pages/Settings/Notifications'));
 const Account = lazy(() => import('./pages/Settings/Account'));
 const Appearance = lazy(() => import('./pages/Settings/Appearance'));
+const Translation = lazy(() => import('./pages/Settings/Translation'));
 const HomeFeeds = lazy(() => import('./pages/Settings/HomeFeeds'));
 const ReadsFeeds = lazy(() => import('./pages/Settings/ReadsFeeds'));
 const DevTools = lazy(() => import('./pages/Settings/DevTools'));
@@ -156,6 +157,7 @@ const AppRouter: Component = () => {
             <Route path="/" component={Menu} />
             <Route path="/account" component={Account} />
             <Route path="/appearance" component={Appearance} />
+            <Route path="/translation" component={Translation} />
             <Route path="/home_feeds" component={HomeFeeds} />
             <Route path="/reads_feeds" component={ReadsFeeds} />
             <Route path="/notifications" component={NotifSettings} />

--- a/src/components/Note/NoteContextMenu.tsx
+++ b/src/components/Note/NoteContextMenu.tsx
@@ -17,6 +17,7 @@ import { useNavigate } from '@solidjs/router';
 import { Kind } from '../../constants';
 import { urlEncode } from '../../utils';
 import { accountStore, addToMuteList, hasPublicKey, removeFromMuteList, setShowPin, showGetStarted } from '../../stores/accountStore';
+import { translateNote } from '../../lib/translation';
 
 const NoteContextMenu: Component<{
   data: NoteContextMenuInfo,
@@ -251,6 +252,14 @@ const NoteContextMenu: Component<{
   const noteContextForEveryone: () => MenuItem[] = () => {
 
     return [
+      {
+        label: intl.formatMessage(tActions.translation.translate),
+        action: () => {
+          const currentNote = note();
+          if (currentNote) translateNote(currentNote);
+          props.onClose();
+        },
+      },
       {
         label: intl.formatMessage(tActions.noteContext.reactions),
         action: () => {

--- a/src/components/ParsedNote/ParsedNote.module.scss
+++ b/src/components/ParsedNote/ParsedNote.module.scss
@@ -119,6 +119,21 @@
   }
 }
 
+.translationStatus {
+  color: var(--text-tertiary-2);
+  font-size: 12px;
+  margin-top: 8px;
+
+  button {
+    color: var(--accent-links);
+    background: none;
+    border: 0;
+    padding: 0;
+    margin-left: 8px;
+    cursor: pointer;
+  }
+}
+
 .reactionNote {
   display: flex;
   width: fit-content;

--- a/src/components/ParsedNote/ParsedNote.tsx
+++ b/src/components/ParsedNote/ParsedNote.tsx
@@ -94,6 +94,7 @@ import NoteVideo from './NoteVideo';
 import { accountStore } from '../../stores/accountStore';
 import UserPoll from '../UserPoll/UserPoll';
 import ZapPoll from '../UserPoll/ZapPoll';
+import { noteTranslations, toggleOriginal, translationProviderName } from '../../lib/translation';
 
 const groupGridLimit = 5;
 
@@ -242,7 +243,8 @@ const ParsedNote: Component<{
   const rootNote = () => props.rootNote || props.note;
 
   const noteContent = () => {
-    const content = props.note.content || '';
+    const translation = noteTranslations[props.note.id];
+    const content = translation?.status === 'translated' && !translation.showOriginal ? translation.text || '' : props.note.content || '';
     const charLimit = 7 * shortNoteChars;
 
     if (!props.shorten || content.length < charLimit) return content;
@@ -2092,6 +2094,20 @@ const ParsedNote: Component<{
         <span class={styles.more}>
           ... <span class="linkish">{intl.formatMessage(actions.seeMore)}</span>
         </span>
+      </Show>
+      <Show when={noteTranslations[props.note.id]?.status === 'loading'}>
+        <div class={styles.translationStatus}>{intl.formatMessage(actions.translation.translating)}</div>
+      </Show>
+      <Show when={noteTranslations[props.note.id]?.status === 'error'}>
+        <div class={styles.translationStatus}>{intl.formatMessage(actions.translation.failed)}</div>
+      </Show>
+      <Show when={noteTranslations[props.note.id]?.status === 'translated'}>
+        <div class={styles.translationStatus}>
+          <span>{intl.formatMessage(actions.translation.attribution, { provider: translationProviderName(noteTranslations[props.note.id].provider!) })}</span>
+          <button type="button" onClick={() => toggleOriginal(props.note.id)}>
+            {intl.formatMessage(noteTranslations[props.note.id].showOriginal ? actions.translation.showTranslation : actions.translation.showOriginal)}
+          </button>
+        </div>
       </Show>
     </div>
   );

--- a/src/lib/translation.ts
+++ b/src/lib/translation.ts
@@ -1,0 +1,139 @@
+import { createStore } from 'solid-js/store';
+import { PrimalNote } from '../types/primal';
+import { restoreTranslationContent, sanitizeForTranslation } from './translationSanitizer';
+
+export type TranslationProvider = 'libretranslate' | 'google' | 'deepl';
+
+export type TranslationSettings = {
+  enabled: boolean,
+  provider: TranslationProvider,
+  apiKey: string,
+  libreTranslateUrl: string,
+  targetLanguage: string,
+};
+
+
+export type NoteTranslation = {
+  status: 'idle' | 'loading' | 'translated' | 'error',
+  text?: string,
+  provider?: TranslationProvider,
+  showOriginal?: boolean,
+};
+
+const settingsKey = 'primal.translation.settings';
+const cacheKey = 'primal.translation.cache';
+const cacheLimit = 100;
+const cacheByteLimit = 1024 * 1024;
+
+const defaultSettings = (): TranslationSettings => ({
+  enabled: false,
+  provider: 'libretranslate',
+  apiKey: '',
+  libreTranslateUrl: 'https://libretranslate.com',
+  targetLanguage: document.documentElement.lang || navigator.language || 'en',
+});
+
+const readSettings = (): TranslationSettings => {
+  try {
+    return { ...defaultSettings(), ...JSON.parse(localStorage.getItem(settingsKey) || '{}') };
+  } catch {
+    return defaultSettings();
+  }
+};
+
+export const [translationSettings, setTranslationSettings] = createStore<TranslationSettings>(readSettings());
+export const [noteTranslations, setNoteTranslations] = createStore<Record<string, NoteTranslation>>({});
+
+export const saveTranslationSettings = (settings: Partial<TranslationSettings>) => {
+  setTranslationSettings(settings);
+  localStorage.setItem(settingsKey, JSON.stringify(translationSettings));
+};
+
+export { restoreTranslationContent, sanitizeForTranslation, SanitizedContent } from './translationSanitizer';
+
+type CacheEntry = { key: string, text: string, provider: TranslationProvider, savedAt: number };
+
+const readCache = (): CacheEntry[] => {
+  try {
+    const cache = JSON.parse(localStorage.getItem(cacheKey) || '[]');
+    return Array.isArray(cache) ? cache : [];
+  } catch {
+    return [];
+  }
+};
+
+const saveCache = (entry: CacheEntry) => {
+  const cache = [entry, ...readCache().filter(item => item.key !== entry.key)].slice(0, cacheLimit);
+  while (cache.length && new Blob([JSON.stringify(cache)]).size > cacheByteLimit) cache.pop();
+  localStorage.setItem(cacheKey, JSON.stringify(cache));
+};
+
+const digest = async (content: string) => {
+  const bytes = new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(content)));
+  return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+};
+
+const providerName = (provider: TranslationProvider) => ({
+  libretranslate: 'LibreTranslate', google: 'Google Cloud Translation', deepl: 'DeepL',
+}[provider]);
+
+const translateWithProvider = async (text: string, settings: TranslationSettings) => {
+  if (settings.provider === 'google') {
+    if (!settings.apiKey) throw new Error('missing_key');
+    const response = await fetch(`https://translation.googleapis.com/language/translate/v2?key=${encodeURIComponent(settings.apiKey)}`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ q: text, target: settings.targetLanguage, format: 'text' }),
+    });
+    const data = await response.json();
+    if (!response.ok || !data.data?.translations?.[0]?.translatedText) throw new Error('provider_error');
+    return data.data.translations[0].translatedText as string;
+  }
+
+  if (settings.provider === 'deepl') {
+    if (!settings.apiKey) throw new Error('missing_key');
+    const response = await fetch('https://api.deepl.com/v2/translate', {
+      method: 'POST', headers: { Authorization: `DeepL-Auth-Key ${settings.apiKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: [text], target_lang: settings.targetLanguage.split('-')[0].toUpperCase() }),
+    });
+    const data = await response.json();
+    if (!response.ok || !data.translations?.[0]?.text) throw new Error('provider_error');
+    return data.translations[0].text as string;
+  }
+
+  if (!settings.libreTranslateUrl) throw new Error('missing_url');
+  const response = await fetch(`${settings.libreTranslateUrl.replace(/\/$/, '')}/translate`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ q: text, source: 'auto', target: settings.targetLanguage, format: 'text' }),
+  });
+  const data = await response.json();
+  if (!response.ok || !data.translatedText) throw new Error('provider_error');
+  return data.translatedText as string;
+};
+
+export const translateNote = async (note: PrimalNote) => {
+  const settings = { ...translationSettings };
+  const id = note.id;
+  if (noteTranslations[id]?.status === 'loading') return;
+  if (!settings.enabled) {
+    setNoteTranslations(id, { status: 'error' });
+    return;
+  }
+
+  setNoteTranslations(id, { status: 'loading' });
+  try {
+    const { content, placeholders } = sanitizeForTranslation(note.content || '');
+    const key = await digest(`${note.content}\n${settings.targetLanguage}\n${settings.provider}`);
+    const cached = readCache().find(item => item.key === key);
+    const translated = cached?.text || await translateWithProvider(content, settings);
+    if (!cached) saveCache({ key, text: translated, provider: settings.provider, savedAt: Date.now() });
+    setNoteTranslations(id, { status: 'translated', text: restoreTranslationContent(translated, placeholders), provider: settings.provider });
+  } catch {
+    setNoteTranslations(id, { status: 'error' });
+  }
+};
+
+export const toggleOriginal = (id: string) => {
+  setNoteTranslations(id, 'showOriginal', original => !original);
+};
+
+export const translationProviderName = providerName;

--- a/src/lib/translationSanitizer.ts
+++ b/src/lib/translationSanitizer.ts
@@ -1,0 +1,17 @@
+export type SanitizedContent = { content: string, placeholders: string[] };
+
+const placeholderPattern = /__PRIMAL_PROTECTED_(\d+)__/g;
+const protectedTokenPattern = /nostr:(?:npub|nprofile|note|nevent|naddr)1[023456789acdefghjklmnpqrstuvwxyz]+|https?:\/\/[^\s]+|www\.[^\s]+|#[\p{L}\p{N}_-]+|:[A-Za-z0-9_+-]+:/giu;
+
+/** Replaces tokens that must never leave the client before provider requests. */
+export const sanitizeForTranslation = (content: string): SanitizedContent => {
+  const placeholders: string[] = [];
+  const sanitized = content.replace(protectedTokenPattern, (token) => {
+    const index = placeholders.push(token) - 1;
+    return `__PRIMAL_PROTECTED_${index}__`;
+  });
+  return { content: sanitized, placeholders };
+};
+
+export const restoreTranslationContent = (content: string, placeholders: string[]) =>
+  content.replace(placeholderPattern, (match, index) => placeholders[Number(index)] || match);

--- a/src/pages/Settings/Menu.tsx
+++ b/src/pages/Settings/Menu.tsx
@@ -37,6 +37,11 @@ const Menu: Component = () => {
           <div class={styles.chevron}></div>
         </A>
 
+        <A href="/settings/translation">
+          {intl.formatMessage(t.translation.title)}
+          <div class={styles.chevron}></div>
+        </A>
+
         <A href="/settings/home_feeds">
           {intl.formatMessage(t.homeFeeds.title)}
           <div class={styles.chevron}></div>

--- a/src/pages/Settings/Settings.module.scss
+++ b/src/pages/Settings/Settings.module.scss
@@ -87,6 +87,25 @@
   border-top: 1px solid var(--devider);
 }
 
+.translationField {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 20px;
+  color: var(--text-secondary);
+
+  input, select {
+    box-sizing: border-box;
+    width: min(440px, 100%);
+    min-height: 38px;
+    padding: 8px;
+    border: 1px solid var(--devider);
+    border-radius: var(--border-radius-small);
+    background: var(--background-input);
+    color: var(--text-primary);
+  }
+}
+
 .settingsContentFull {
   padding-inline: 0px;
   padding-block: 8px;

--- a/src/pages/Settings/Translation.tsx
+++ b/src/pages/Settings/Translation.tsx
@@ -1,0 +1,53 @@
+import { Component, Show } from 'solid-js';
+import { A } from '@solidjs/router';
+import { useIntl } from '@cookbook/solid-intl';
+import PageCaption from '../../components/PageCaption/PageCaption';
+import PageTitle from '../../components/PageTitle/PageTitle';
+import CheckBox from '../../components/Checkbox/CheckBox';
+import { settings as t } from '../../translations';
+import { saveTranslationSettings, translationSettings, TranslationProvider } from '../../lib/translation';
+import styles from './Settings.module.scss';
+
+const Translation: Component = () => {
+  const intl = useIntl();
+
+  return <div>
+    <PageTitle title={`${intl.formatMessage(t.translation.title)} ${intl.formatMessage(t.title)}`} />
+    <PageCaption>
+      <A href="/settings">{intl.formatMessage(t.index.title)}</A>:&nbsp;
+      <div>{intl.formatMessage(t.translation.title)}</div>
+    </PageCaption>
+    <div class={styles.settingsContent}>
+      <div class={styles.settingsCaption}>{intl.formatMessage(t.translation.caption)}</div>
+      <CheckBox checked={translationSettings.enabled} onChange={(enabled) => saveTranslationSettings({ enabled })}>
+        <div class={styles.appearanceCheckLabel}>{intl.formatMessage(t.translation.enable)}</div>
+      </CheckBox>
+      <label class={styles.translationField}>
+        <span>{intl.formatMessage(t.translation.provider)}</span>
+        <select value={translationSettings.provider} onChange={(event) => saveTranslationSettings({ provider: event.currentTarget.value as TranslationProvider })}>
+          <option value="libretranslate">LibreTranslate</option>
+          <option value="google">Google Cloud Translation</option>
+          <option value="deepl">DeepL</option>
+        </select>
+      </label>
+      <Show when={translationSettings.provider === 'libretranslate'}>
+        <label class={styles.translationField}>
+          <span>{intl.formatMessage(t.translation.libreTranslateUrl)}</span>
+          <input type="url" value={translationSettings.libreTranslateUrl} onChange={(event) => saveTranslationSettings({ libreTranslateUrl: event.currentTarget.value })} />
+        </label>
+      </Show>
+      <Show when={translationSettings.provider !== 'libretranslate'}>
+        <label class={styles.translationField}>
+          <span>{intl.formatMessage(t.translation.apiKey)}</span>
+          <input type="password" value={translationSettings.apiKey} onChange={(event) => saveTranslationSettings({ apiKey: event.currentTarget.value })} />
+        </label>
+      </Show>
+      <label class={styles.translationField}>
+        <span>{intl.formatMessage(t.translation.targetLanguage)}</span>
+        <input type="text" value={translationSettings.targetLanguage} onChange={(event) => saveTranslationSettings({ targetLanguage: event.currentTarget.value })} />
+      </label>
+    </div>
+  </div>;
+};
+
+export default Translation;

--- a/src/translations.ts
+++ b/src/translations.ts
@@ -176,6 +176,14 @@ export const pin = {
 };
 
 export const actions = {
+  translation: {
+    translate: { id: 'actions.translation.translate', defaultMessage: 'Translate', description: 'Translate note context-menu action' },
+    showOriginal: { id: 'actions.translation.showOriginal', defaultMessage: 'Show original', description: 'Show original note action' },
+    showTranslation: { id: 'actions.translation.showTranslation', defaultMessage: 'Show translation', description: 'Show translated note action' },
+    translating: { id: 'actions.translation.translating', defaultMessage: 'Translating…', description: 'Translation loading status' },
+    failed: { id: 'actions.translation.failed', defaultMessage: 'Translation unavailable. Check Translation settings.', description: 'Translation error status' },
+    attribution: { id: 'actions.translation.attribution', defaultMessage: 'Translated by {provider}', description: 'Translation provider attribution' },
+  },
   resetRelays: {
     id: 'actions.resetRelays',
     defaultMessage: 'Reset relays',
@@ -1783,6 +1791,15 @@ export const eventQueue = {
 }
 
 export const settings = {
+  translation: {
+    title: { id: 'settings.translation.title', defaultMessage: 'Translation', description: 'Title of translation settings' },
+    caption: { id: 'settings.translation.caption', defaultMessage: 'Translate notes with your chosen provider', description: 'Translation settings description' },
+    enable: { id: 'settings.translation.enable', defaultMessage: 'Enable note translation', description: 'Enable translation setting' },
+    provider: { id: 'settings.translation.provider', defaultMessage: 'Translation provider', description: 'Translation provider setting label' },
+    apiKey: { id: 'settings.translation.apiKey', defaultMessage: 'API key', description: 'Translation API key setting label' },
+    libreTranslateUrl: { id: 'settings.translation.libreTranslateUrl', defaultMessage: 'LibreTranslate URL', description: 'LibreTranslate server URL setting label' },
+    targetLanguage: { id: 'settings.translation.targetLanguage', defaultMessage: 'Target language', description: 'Translation target language setting label' },
+  },
   index: {
     title: {
       id: 'settings.index.title',


### PR DESCRIPTION
Closes #133

Implements inline note translation following the review criteria published on #202:

1. **Official APIs only** — provider abstraction with LibreTranslate (self-hosted or configured instance URL), Google Cloud Translation v2 (`translation.googleapis.com/language/translate/v2`, user-supplied key), and DeepL API (user-supplied key). No undocumented endpoints.
2. **Content sanitization** — `nostr:` entity refs (npub/nprofile/note/nevent/naddr), URLs, hashtags, and custom emoji shortcodes are replaced with stable placeholders before any provider request and restored locally afterwards (round-trip covered by `scripts/check-translation-sanitize.ts`).
3. **Caching** — SHA-256(content + target lang + provider) keyed cache in localStorage, capped at 100 entries / 1 MiB.
4. **i18n** — all new user-facing strings defined in `src/translations.ts`; `npm run extract` run.

**UX**: Translate item in the note context menu; inline loading/error states; "Translated by <provider>" attribution; Show original / Show translation toggle. Settings → Translation page: enable, provider select, API key / instance URL, target language (defaults to app locale).

**Validation**
- `npm ci`
- `node --experimental-strip-types scripts/check-translation-sanitize.ts` → PASS
- `npm run extract` → completed
- `npm run build` → success (pre-existing chunk-size warnings only)

No new dependencies. Happy to adjust anything — scope, UX placement, or provider set.