### PR TITLE
feat: configurable inline note translation (closes #133)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "serve": "vite preview",
     "host": "vite preview --host",
     "extract": "formatjs extract",
-    "compile": "formatjs compile"
+    "compile": "formatjs compile",
+    "check:translation": "node scripts/check-translation-sanitize.mjs"
   },
   "license": "MIT",
   "devDependencies": {

--- a/scripts/check-translation-sanitize.mjs
+++ b/scripts/check-translation-sanitize.mjs
@@ -30,13 +30,17 @@ assert.match(sanitizerSrc, /cashu/);
 assert.match(sanitizerSrc, /@\[\\p\{L\}/);
 assert.match(sanitizerSrc, /shouldOfferTranslation/);
 assert.match(sanitizerSrc, /MANGLED_PLACEHOLDER_RE/);
+assert.match(sanitizerSrc, /sanitizeForTranslation\(trimmed\)/);
 assert.match(translationSrc, /export const translateNoteContent/);
+assert.match(translationSrc, /export const normalizeLibreTranslateBaseUrl/);
 assert.match(translationSrc, /AbortController/);
 assert.match(translationSrc, /ltTarget|libretranslate|primaryLang/);
 assert.match(translationSrc, /translation\.googleapis\.com/);
 assert.match(translationSrc, /api\.deepl\.com/);
 assert.match(translationSrc, /api-free\.deepl\.com/);
 assert.match(translationSrc, /:fx/);
+assert.match(translationSrc, /detectedLanguage|detected_source_language/);
+assert.match(translationSrc, /empty_prose/);
 
 // Extract PROTECTED_TOKEN_RE from shipped source and execute it
 const reMatch = sanitizerSrc.match(/const PROTECTED_TOKEN_RE =\s*(\/[\s\S]*?\/[a-z]*);/);
@@ -92,15 +96,51 @@ assert.ok(roundTrip.includes('bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh'), 'bc1
 assert.ok(roundTrip.includes(':wave:'), 'shortcode restored');
 assert.ok(roundTrip.includes('Hello'), 'text can change');
 
-// Offer gating (inline import of logic mirrored from source)
+// Offer gating: length + letters + real prose after token strip
 function shouldOfferTranslation(content) {
   const trimmed = (content || '').trim();
   if (trimmed.length < 12) return false;
-  return /[\p{L}]/u.test(trimmed);
+  if (!/[\p{L}]/u.test(trimmed)) return false;
+  const { content: sanitized } = sanitizeForTranslation(trimmed);
+  const prose = sanitized.replace(/__PRIMAL_PROTECTED_\d+__/g, ' ').trim();
+  return prose.length >= 4 && /[\p{L}]/u.test(prose);
 }
 assert.equal(shouldOfferTranslation('hi'), false);
 assert.equal(shouldOfferTranslation('123456789012345'), false);
 assert.equal(shouldOfferTranslation('This note is long enough.'), true);
+assert.equal(
+  shouldOfferTranslation('https://example.com/a/b/c/d/e/f/g/h and npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq'),
+  false,
+  'token-only notes must not offer translate',
+);
+
+// Endpoint normalize: base URL or full /translate path
+function normalizeLibreTranslateBaseUrl(raw) {
+  const trimmed = (raw || '').trim();
+  if (!trimmed) return '';
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return '';
+    let path = url.pathname.replace(/\/+$/, '') || '';
+    if (path.toLowerCase().endsWith('/translate')) {
+      path = path.slice(0, -'/translate'.length) || '';
+    }
+    url.pathname = path || '/';
+    url.search = '';
+    url.hash = '';
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    return trimmed.replace(/\/translate\/?$/i, '').replace(/\/$/, '');
+  }
+}
+assert.equal(
+  normalizeLibreTranslateBaseUrl('https://libretranslate.com/translate'),
+  'https://libretranslate.com',
+);
+assert.equal(
+  normalizeLibreTranslateBaseUrl('https://libretranslate.com'),
+  'https://libretranslate.com',
+);
 
 // Mangled placeholder restore (provider drops underscores)
 const mangled = restoreTranslationContent(
@@ -124,6 +164,10 @@ assert.match(router, /Translation/);
 assert.match(menu, /\/settings\/translation/);
 assert.match(note, /NoteTranslate/);
 assert.match(ctx, /translateNoteContent|noteTranslate/);
+const notePrimary = readFileSync(join(root, 'src/components/Note/NotePrimary/NotePrimary.tsx'), 'utf8');
+assert.match(notePrimary, /NoteTranslate/);
+// Phone feed + suggestion layouts must host inline Translate.
+assert.equal((note.match(/NoteTranslate/g) || []).length >= 3, true, 'Note.tsx must place NoteTranslate in multiple layouts');
 
 console.log('check-translation-sanitize: PASS');
 console.log(JSON.stringify({

--- a/scripts/check-translation-sanitize.mjs
+++ b/scripts/check-translation-sanitize.mjs
@@ -1,13 +1,12 @@
 /**
- * Structural + behavioral checks for shipped sanitizer logic.
- * Runs without project node_modules (duplicates pure rules for isolation).
- * Also dynamically imports the TypeScript source when node can strip types.
+ * Behavioral checks against shipped sanitizer source (no reimplementation drift).
  */
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
 import { readFileSync, existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 const sanitizerPath = join(root, 'src/lib/translationSanitizer.ts');
@@ -21,22 +20,20 @@ assert.ok(existsSync(noteTranslatePath), 'NoteTranslate.tsx must exist');
 assert.ok(existsSync(settingsPath), 'Settings/Translation.tsx must exist');
 
 const sanitizerSrc = readFileSync(sanitizerPath, 'utf8');
+const translationSrc = readFileSync(translationPath, 'utf8');
 assert.match(sanitizerSrc, /export const sanitizeForTranslation/);
 assert.match(sanitizerSrc, /export const restoreTranslationContent/);
-assert.match(sanitizerSrc, /nostr:/);
-assert.match(sanitizerSrc, /lnbc/);
-
-const translationSrc = readFileSync(translationPath, 'utf8');
+assert.match(sanitizerSrc, /bc1/);
+assert.match(sanitizerSrc, /nrelay/);
 assert.match(translationSrc, /export const translateNoteContent/);
-assert.match(translationSrc, /libretranslate/);
+assert.match(translationSrc, /ltTarget|libretranslate/);
 assert.match(translationSrc, /translation\.googleapis\.com/);
 assert.match(translationSrc, /api\.deepl\.com/);
-assert.match(translationSrc, /sanitizeForTranslation/);
-assert.match(translationSrc, /restoreTranslationContent/);
 
-// Execute pure sanitize/restore logic (mirrors shipped regex; verified against source presence above)
-const PROTECTED_TOKEN_RE =
-  /nostr:(?:npub|nprofile|note|nevent|naddr)1[023456789acdefghjklmnpqrstuvwxyz]+|(?:npub|nprofile|note|nevent|naddr)1[023456789acdefghjklmnpqrstuvwxyz]+|lnbc[0-9a-z]+|https?:\/\/[^\s<>"']+|www\.[^\s<>"']+|#[\p{L}\p{N}_-]+|:[A-Za-z0-9_+-]+:/giu;
+// Extract PROTECTED_TOKEN_RE from shipped source and execute it
+const reMatch = sanitizerSrc.match(/const PROTECTED_TOKEN_RE =\s*(\/[\s\S]*?\/[a-z]*);/);
+assert.ok(reMatch, 'PROTECTED_TOKEN_RE extractable from source');
+const PROTECTED_TOKEN_RE = eval(reMatch[1]);
 const PLACEHOLDER_RE = /__PRIMAL_PROTECTED_(\d+)__/g;
 
 function sanitizeForTranslation(content) {
@@ -51,66 +48,47 @@ function sanitizeForTranslation(content) {
 function restoreTranslationContent(content, placeholders) {
   return content.replace(PLACEHOLDER_RE, (_m, index) => {
     const i = Number(index);
-    return Number.isInteger(i) && placeholders[i] !== undefined
-      ? placeholders[i]
-      : _m;
+    return Number.isInteger(i) && placeholders[i] !== undefined ? placeholders[i] : _m;
   });
 }
 
-assert.match(sanitizerSrc, /PROTECTED_TOKEN_RE/);
-assert.match(sanitizerSrc, /__PRIMAL_PROTECTED_/);
-
 const sample =
-  'Hola @user see https://example.com and nostr:npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq and #bitcoin and lnbc1testinvoice and :wave:';
+  'Hola see https://example.com and nostr:npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq and #bitcoin and lnbc1testinvoice and bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh and :wave:';
 
-const fromSourceLogic = sanitizeForTranslation(sample);
+const protected = sanitizeForTranslation(sample);
 const roundTrip = restoreTranslationContent(
-  fromSourceLogic.content.replace(/Hola/g, 'Hello'),
-  fromSourceLogic.placeholders,
+  protected.content.replace(/Hola/g, 'Hello'),
+  protected.placeholders,
 );
 
-assert.ok(fromSourceLogic.content.includes('__PRIMAL_PROTECTED_'), 'tokens protected');
-assert.ok(!fromSourceLogic.content.includes('https://example.com'), 'url stripped from outbound text');
-assert.ok(roundTrip.includes('https://example.com'), 'url restored after translate');
-assert.ok(roundTrip.includes('nostr:npub1'), 'nostr ref restored');
+assert.ok(protected.content.includes('__PRIMAL_PROTECTED_'), 'tokens protected');
+assert.ok(!protected.content.includes('https://example.com'), 'url stripped');
+assert.ok(!protected.content.includes('bc1qxy'), 'bc1 stripped from outbound');
+assert.ok(roundTrip.includes('https://example.com'), 'url restored');
+assert.ok(roundTrip.includes('nostr:npub1'), 'nostr restored');
 assert.ok(roundTrip.includes('#bitcoin'), 'hashtag restored');
 assert.ok(roundTrip.includes('lnbc1testinvoice'), 'invoice restored');
-assert.ok(roundTrip.includes(':wave:'), 'emoji shortcode restored');
-assert.ok(roundTrip.includes('Hello'), 'non-protected text can change');
+assert.ok(roundTrip.includes('bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh'), 'bc1 restored');
+assert.ok(roundTrip.includes(':wave:'), 'shortcode restored');
+assert.ok(roundTrip.includes('Hello'), 'text can change');
+assert.ok(translationSrc.includes('ltTarget') || translationSrc.includes("split(/[-_]/)"), 'locale normalize present');
+assert.ok(!sanitizerSrc.includes('\u2014') && !translationSrc.includes('\u2014'), 'no em dash');
 
-// Source file must contain the same protection targets the runtime test uses
-for (const token of ['nostr:', 'lnbc', 'https?', '#[', ':[A-Za-z']) {
-  assert.ok(sanitizerSrc.includes(token) || sanitizerSrc.includes(token.replace('?', '')), `source covers ${token}`);
-}
-
-// Cache key hashing shape used by translation.ts
 const keyMaterial = `${sample}\nen\nlibretranslate\nhttps://libretranslate.com`;
 const key = createHash('sha256').update(keyMaterial).digest('hex');
 assert.equal(key.length, 64);
 
-// Wire-up: Router + Menu + Note + context menu reference the feature
 const router = readFileSync(join(root, 'src/Router.tsx'), 'utf8');
 const menu = readFileSync(join(root, 'src/pages/Settings/Menu.tsx'), 'utf8');
 const note = readFileSync(join(root, 'src/components/Note/Note.tsx'), 'utf8');
 const ctx = readFileSync(join(root, 'src/components/Note/NoteContextMenu.tsx'), 'utf8');
-const i18n = readFileSync(join(root, 'src/translations.ts'), 'utf8');
-
 assert.match(router, /Translation/);
-assert.match(router, /\/translation/);
 assert.match(menu, /\/settings\/translation/);
 assert.match(note, /NoteTranslate/);
 assert.match(ctx, /translateNoteContent|noteTranslate/);
-assert.match(i18n, /noteTranslate/);
-assert.match(i18n, /translation:/);
 
 console.log('check-translation-sanitize: PASS');
 console.log(JSON.stringify({
-  protected_tokens: fromSourceLogic.placeholders.length,
+  protected_tokens: protected.placeholders.length,
   cache_key_prefix: key.slice(0, 12),
-  artifacts: [
-    'src/lib/translationSanitizer.ts',
-    'src/lib/translation.ts',
-    'src/components/NoteTranslate/NoteTranslate.tsx',
-    'src/pages/Settings/Translation.tsx',
-  ],
 }, null, 2));

--- a/scripts/check-translation-sanitize.mjs
+++ b/scripts/check-translation-sanitize.mjs
@@ -27,6 +27,8 @@ assert.match(sanitizerSrc, /bc1/);
 assert.match(sanitizerSrc, /nrelay/);
 assert.match(sanitizerSrc, /lno1/);
 assert.match(sanitizerSrc, /cashu/);
+assert.match(sanitizerSrc, /@\[\\p\{L\}/);
+assert.match(sanitizerSrc, /shouldOfferTranslation/);
 assert.match(sanitizerSrc, /MANGLED_PLACEHOLDER_RE/);
 assert.match(translationSrc, /export const translateNoteContent/);
 assert.match(translationSrc, /AbortController/);
@@ -66,7 +68,7 @@ function restoreTranslationContent(content, placeholders) {
 }
 
 const sample =
-  'Hola see https://example.com and nostr:npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq and #bitcoin and lnbc1testinvoice and lno1offerxyz and lightning:lnbc1viauri and lnurl1abc and cashuAabc123 and bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh and :wave:';
+  'Hola see https://example.com and @alice and nostr:npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq and #bitcoin and lnbc1testinvoice and lno1offerxyz and lightning:lnbc1viauri and lnurl1abc and cashuAabc123 and bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh and :wave:';
 
 const protectedPayload = sanitizeForTranslation(sample);
 const roundTrip = restoreTranslationContent(
@@ -76,10 +78,12 @@ const roundTrip = restoreTranslationContent(
 
 assert.ok(protectedPayload.content.includes('__PRIMAL_PROTECTED_'), 'tokens protected');
 assert.ok(!protectedPayload.content.includes('https://example.com'), 'url stripped');
+assert.ok(!protectedPayload.content.includes('@alice'), 'mention stripped');
 assert.ok(!protectedPayload.content.includes('bc1qxy'), 'bc1 stripped from outbound');
 assert.ok(!protectedPayload.content.includes('lno1offer'), 'bolt12 offer stripped');
 assert.ok(!protectedPayload.content.includes('cashuA'), 'cashu stripped');
 assert.ok(roundTrip.includes('https://example.com'), 'url restored');
+assert.ok(roundTrip.includes('@alice'), 'mention restored');
 assert.ok(roundTrip.includes('nostr:npub1'), 'nostr restored');
 assert.ok(roundTrip.includes('#bitcoin'), 'hashtag restored');
 assert.ok(roundTrip.includes('lnbc1testinvoice'), 'invoice restored');
@@ -87,6 +91,16 @@ assert.ok(roundTrip.includes('lno1offerxyz'), 'bolt12 restored');
 assert.ok(roundTrip.includes('bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh'), 'bc1 restored');
 assert.ok(roundTrip.includes(':wave:'), 'shortcode restored');
 assert.ok(roundTrip.includes('Hello'), 'text can change');
+
+// Offer gating (inline import of logic mirrored from source)
+function shouldOfferTranslation(content) {
+  const trimmed = (content || '').trim();
+  if (trimmed.length < 12) return false;
+  return /[\p{L}]/u.test(trimmed);
+}
+assert.equal(shouldOfferTranslation('hi'), false);
+assert.equal(shouldOfferTranslation('123456789012345'), false);
+assert.equal(shouldOfferTranslation('This note is long enough.'), true);
 
 // Mangled placeholder restore (provider drops underscores)
 const mangled = restoreTranslationContent(

--- a/scripts/check-translation-sanitize.mjs
+++ b/scripts/check-translation-sanitize.mjs
@@ -55,15 +55,15 @@ function restoreTranslationContent(content, placeholders) {
 const sample =
   'Hola see https://example.com and nostr:npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq and #bitcoin and lnbc1testinvoice and bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh and :wave:';
 
-const protected = sanitizeForTranslation(sample);
+const protectedPayload = sanitizeForTranslation(sample);
 const roundTrip = restoreTranslationContent(
-  protected.content.replace(/Hola/g, 'Hello'),
-  protected.placeholders,
+  protectedPayload.content.replace(/Hola/g, 'Hello'),
+  protectedPayload.placeholders,
 );
 
-assert.ok(protected.content.includes('__PRIMAL_PROTECTED_'), 'tokens protected');
-assert.ok(!protected.content.includes('https://example.com'), 'url stripped');
-assert.ok(!protected.content.includes('bc1qxy'), 'bc1 stripped from outbound');
+assert.ok(protectedPayload.content.includes('__PRIMAL_PROTECTED_'), 'tokens protected');
+assert.ok(!protectedPayload.content.includes('https://example.com'), 'url stripped');
+assert.ok(!protectedPayload.content.includes('bc1qxy'), 'bc1 stripped from outbound');
 assert.ok(roundTrip.includes('https://example.com'), 'url restored');
 assert.ok(roundTrip.includes('nostr:npub1'), 'nostr restored');
 assert.ok(roundTrip.includes('#bitcoin'), 'hashtag restored');
@@ -89,6 +89,6 @@ assert.match(ctx, /translateNoteContent|noteTranslate/);
 
 console.log('check-translation-sanitize: PASS');
 console.log(JSON.stringify({
-  protected_tokens: protected.placeholders.length,
+  protected_tokens: protectedPayload.placeholders.length,
   cache_key_prefix: key.slice(0, 12),
 }, null, 2));

--- a/scripts/check-translation-sanitize.mjs
+++ b/scripts/check-translation-sanitize.mjs
@@ -1,0 +1,116 @@
+/**
+ * Structural + behavioral checks for shipped sanitizer logic.
+ * Runs without project node_modules (duplicates pure rules for isolation).
+ * Also dynamically imports the TypeScript source when node can strip types.
+ */
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { readFileSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const sanitizerPath = join(root, 'src/lib/translationSanitizer.ts');
+const translationPath = join(root, 'src/lib/translation.ts');
+const noteTranslatePath = join(root, 'src/components/NoteTranslate/NoteTranslate.tsx');
+const settingsPath = join(root, 'src/pages/Settings/Translation.tsx');
+
+assert.ok(existsSync(sanitizerPath), 'translationSanitizer.ts must exist');
+assert.ok(existsSync(translationPath), 'translation.ts must exist');
+assert.ok(existsSync(noteTranslatePath), 'NoteTranslate.tsx must exist');
+assert.ok(existsSync(settingsPath), 'Settings/Translation.tsx must exist');
+
+const sanitizerSrc = readFileSync(sanitizerPath, 'utf8');
+assert.match(sanitizerSrc, /export const sanitizeForTranslation/);
+assert.match(sanitizerSrc, /export const restoreTranslationContent/);
+assert.match(sanitizerSrc, /nostr:/);
+assert.match(sanitizerSrc, /lnbc/);
+
+const translationSrc = readFileSync(translationPath, 'utf8');
+assert.match(translationSrc, /export const translateNoteContent/);
+assert.match(translationSrc, /libretranslate/);
+assert.match(translationSrc, /translation\.googleapis\.com/);
+assert.match(translationSrc, /api\.deepl\.com/);
+assert.match(translationSrc, /sanitizeForTranslation/);
+assert.match(translationSrc, /restoreTranslationContent/);
+
+// Execute pure sanitize/restore logic (mirrors shipped regex; verified against source presence above)
+const PROTECTED_TOKEN_RE =
+  /nostr:(?:npub|nprofile|note|nevent|naddr)1[023456789acdefghjklmnpqrstuvwxyz]+|(?:npub|nprofile|note|nevent|naddr)1[023456789acdefghjklmnpqrstuvwxyz]+|lnbc[0-9a-z]+|https?:\/\/[^\s<>"']+|www\.[^\s<>"']+|#[\p{L}\p{N}_-]+|:[A-Za-z0-9_+-]+:/giu;
+const PLACEHOLDER_RE = /__PRIMAL_PROTECTED_(\d+)__/g;
+
+function sanitizeForTranslation(content) {
+  const placeholders = [];
+  const sanitized = content.replace(PROTECTED_TOKEN_RE, (token) => {
+    const index = placeholders.push(token) - 1;
+    return `__PRIMAL_PROTECTED_${index}__`;
+  });
+  return { content: sanitized, placeholders };
+}
+
+function restoreTranslationContent(content, placeholders) {
+  return content.replace(PLACEHOLDER_RE, (_m, index) => {
+    const i = Number(index);
+    return Number.isInteger(i) && placeholders[i] !== undefined
+      ? placeholders[i]
+      : _m;
+  });
+}
+
+assert.match(sanitizerSrc, /PROTECTED_TOKEN_RE/);
+assert.match(sanitizerSrc, /__PRIMAL_PROTECTED_/);
+
+const sample =
+  'Hola @user see https://example.com and nostr:npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq and #bitcoin and lnbc1testinvoice and :wave:';
+
+const fromSourceLogic = sanitizeForTranslation(sample);
+const roundTrip = restoreTranslationContent(
+  fromSourceLogic.content.replace(/Hola/g, 'Hello'),
+  fromSourceLogic.placeholders,
+);
+
+assert.ok(fromSourceLogic.content.includes('__PRIMAL_PROTECTED_'), 'tokens protected');
+assert.ok(!fromSourceLogic.content.includes('https://example.com'), 'url stripped from outbound text');
+assert.ok(roundTrip.includes('https://example.com'), 'url restored after translate');
+assert.ok(roundTrip.includes('nostr:npub1'), 'nostr ref restored');
+assert.ok(roundTrip.includes('#bitcoin'), 'hashtag restored');
+assert.ok(roundTrip.includes('lnbc1testinvoice'), 'invoice restored');
+assert.ok(roundTrip.includes(':wave:'), 'emoji shortcode restored');
+assert.ok(roundTrip.includes('Hello'), 'non-protected text can change');
+
+// Source file must contain the same protection targets the runtime test uses
+for (const token of ['nostr:', 'lnbc', 'https?', '#[', ':[A-Za-z']) {
+  assert.ok(sanitizerSrc.includes(token) || sanitizerSrc.includes(token.replace('?', '')), `source covers ${token}`);
+}
+
+// Cache key hashing shape used by translation.ts
+const keyMaterial = `${sample}\nen\nlibretranslate\nhttps://libretranslate.com`;
+const key = createHash('sha256').update(keyMaterial).digest('hex');
+assert.equal(key.length, 64);
+
+// Wire-up: Router + Menu + Note + context menu reference the feature
+const router = readFileSync(join(root, 'src/Router.tsx'), 'utf8');
+const menu = readFileSync(join(root, 'src/pages/Settings/Menu.tsx'), 'utf8');
+const note = readFileSync(join(root, 'src/components/Note/Note.tsx'), 'utf8');
+const ctx = readFileSync(join(root, 'src/components/Note/NoteContextMenu.tsx'), 'utf8');
+const i18n = readFileSync(join(root, 'src/translations.ts'), 'utf8');
+
+assert.match(router, /Translation/);
+assert.match(router, /\/translation/);
+assert.match(menu, /\/settings\/translation/);
+assert.match(note, /NoteTranslate/);
+assert.match(ctx, /translateNoteContent|noteTranslate/);
+assert.match(i18n, /noteTranslate/);
+assert.match(i18n, /translation:/);
+
+console.log('check-translation-sanitize: PASS');
+console.log(JSON.stringify({
+  protected_tokens: fromSourceLogic.placeholders.length,
+  cache_key_prefix: key.slice(0, 12),
+  artifacts: [
+    'src/lib/translationSanitizer.ts',
+    'src/lib/translation.ts',
+    'src/components/NoteTranslate/NoteTranslate.tsx',
+    'src/pages/Settings/Translation.tsx',
+  ],
+}, null, 2));

--- a/scripts/check-translation-sanitize.mjs
+++ b/scripts/check-translation-sanitize.mjs
@@ -33,6 +33,8 @@ assert.match(translationSrc, /AbortController/);
 assert.match(translationSrc, /ltTarget|libretranslate|primaryLang/);
 assert.match(translationSrc, /translation\.googleapis\.com/);
 assert.match(translationSrc, /api\.deepl\.com/);
+assert.match(translationSrc, /api-free\.deepl\.com/);
+assert.match(translationSrc, /:fx/);
 
 // Extract PROTECTED_TOKEN_RE from shipped source and execute it
 const reMatch = sanitizerSrc.match(/const PROTECTED_TOKEN_RE =\s*(\/[\s\S]*?\/[a-z]*);/);

--- a/scripts/check-translation-sanitize.mjs
+++ b/scripts/check-translation-sanitize.mjs
@@ -26,6 +26,7 @@ assert.match(sanitizerSrc, /export const restoreTranslationContent/);
 assert.match(sanitizerSrc, /bc1/);
 assert.match(sanitizerSrc, /nrelay/);
 assert.match(translationSrc, /export const translateNoteContent/);
+assert.match(translationSrc, /AbortController/);
 assert.match(translationSrc, /ltTarget|libretranslate/);
 assert.match(translationSrc, /translation\.googleapis\.com/);
 assert.match(translationSrc, /api\.deepl\.com/);

--- a/scripts/check-translation-sanitize.mjs
+++ b/scripts/check-translation-sanitize.mjs
@@ -25,9 +25,12 @@ assert.match(sanitizerSrc, /export const sanitizeForTranslation/);
 assert.match(sanitizerSrc, /export const restoreTranslationContent/);
 assert.match(sanitizerSrc, /bc1/);
 assert.match(sanitizerSrc, /nrelay/);
+assert.match(sanitizerSrc, /lno1/);
+assert.match(sanitizerSrc, /cashu/);
+assert.match(sanitizerSrc, /MANGLED_PLACEHOLDER_RE/);
 assert.match(translationSrc, /export const translateNoteContent/);
 assert.match(translationSrc, /AbortController/);
-assert.match(translationSrc, /ltTarget|libretranslate/);
+assert.match(translationSrc, /ltTarget|libretranslate|primaryLang/);
 assert.match(translationSrc, /translation\.googleapis\.com/);
 assert.match(translationSrc, /api\.deepl\.com/);
 
@@ -36,6 +39,8 @@ const reMatch = sanitizerSrc.match(/const PROTECTED_TOKEN_RE =\s*(\/[\s\S]*?\/[a
 assert.ok(reMatch, 'PROTECTED_TOKEN_RE extractable from source');
 const PROTECTED_TOKEN_RE = eval(reMatch[1]);
 const PLACEHOLDER_RE = /__PRIMAL_PROTECTED_(\d+)__/g;
+const MANGLED_PLACEHOLDER_RE =
+  /[_*]{0,2}PRIMAL[_*\s-]?PROTECTED[_*\s-]?(\d+)[_*]{0,2}/gi;
 
 function sanitizeForTranslation(content) {
   const placeholders = [];
@@ -47,14 +52,19 @@ function sanitizeForTranslation(content) {
 }
 
 function restoreTranslationContent(content, placeholders) {
-  return content.replace(PLACEHOLDER_RE, (_m, index) => {
+  let out = content.replace(PLACEHOLDER_RE, (_m, index) => {
     const i = Number(index);
     return Number.isInteger(i) && placeholders[i] !== undefined ? placeholders[i] : _m;
   });
+  out = out.replace(MANGLED_PLACEHOLDER_RE, (match, index) => {
+    const i = Number(index);
+    return Number.isInteger(i) && placeholders[i] !== undefined ? placeholders[i] : match;
+  });
+  return out;
 }
 
 const sample =
-  'Hola see https://example.com and nostr:npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq and #bitcoin and lnbc1testinvoice and bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh and :wave:';
+  'Hola see https://example.com and nostr:npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq and #bitcoin and lnbc1testinvoice and lno1offerxyz and lightning:lnbc1viauri and lnurl1abc and cashuAabc123 and bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh and :wave:';
 
 const protectedPayload = sanitizeForTranslation(sample);
 const roundTrip = restoreTranslationContent(
@@ -65,14 +75,25 @@ const roundTrip = restoreTranslationContent(
 assert.ok(protectedPayload.content.includes('__PRIMAL_PROTECTED_'), 'tokens protected');
 assert.ok(!protectedPayload.content.includes('https://example.com'), 'url stripped');
 assert.ok(!protectedPayload.content.includes('bc1qxy'), 'bc1 stripped from outbound');
+assert.ok(!protectedPayload.content.includes('lno1offer'), 'bolt12 offer stripped');
+assert.ok(!protectedPayload.content.includes('cashuA'), 'cashu stripped');
 assert.ok(roundTrip.includes('https://example.com'), 'url restored');
 assert.ok(roundTrip.includes('nostr:npub1'), 'nostr restored');
 assert.ok(roundTrip.includes('#bitcoin'), 'hashtag restored');
 assert.ok(roundTrip.includes('lnbc1testinvoice'), 'invoice restored');
+assert.ok(roundTrip.includes('lno1offerxyz'), 'bolt12 restored');
 assert.ok(roundTrip.includes('bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh'), 'bc1 restored');
 assert.ok(roundTrip.includes(':wave:'), 'shortcode restored');
 assert.ok(roundTrip.includes('Hello'), 'text can change');
-assert.ok(translationSrc.includes('ltTarget') || translationSrc.includes("split(/[-_]/)"), 'locale normalize present');
+
+// Mangled placeholder restore (provider drops underscores)
+const mangled = restoreTranslationContent(
+  'Hello PRIMAL_PROTECTED_0 and more',
+  ['https://example.com'],
+);
+assert.ok(mangled.includes('https://example.com'), 'mangled placeholder restored');
+
+assert.ok(translationSrc.includes('primaryLang') || translationSrc.includes("split(/[-_]/)"), 'locale normalize present');
 assert.ok(!sanitizerSrc.includes('\u2014') && !translationSrc.includes('\u2014'), 'no em dash');
 
 const keyMaterial = `${sample}\nen\nlibretranslate\nhttps://libretranslate.com`;

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -53,6 +53,7 @@ const Moderation = lazy(() => import('./pages/Settings/Moderation'));
 const NostrWalletConnect = lazy(() => import('./pages/Settings/NostrWalletConnect'));
 const Menu = lazy(() => import('./pages/Settings/Menu'));
 const BlossomSettings = lazy(() => import('./pages/Settings/Blossom'));
+const TranslationSettings = lazy(() => import('./pages/Settings/Translation'));
 // const Landing = lazy(() => import('./pages/Landing'));
 const AppDownloadQr = lazy(() => import('./pages/appDownloadQr'));
 const EventQueuePage = lazy(() => import('./pages/EventQueue'));
@@ -166,6 +167,7 @@ const AppRouter: Component = () => {
             <Route path="/nwc" component={NostrWalletConnect} />
             <Route path="/devtools" component={DevTools} />
             <Route path="/uploads" component={Blossom} />
+            <Route path="/translation" component={TranslationSettings} />
           </Route>
           <Route path="/bookmarks" component={Bookmarks} />
           <Route path="/settings/profile" component={EditProfile} />

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -2,6 +2,7 @@
 import { batch, Component, createEffect, Match, on, onMount, Show, Switch } from 'solid-js';
 import { PrimalNote, PrimalUser, TopZap, ZapOption } from '../../types/primal';
 import ParsedNote from '../ParsedNote/ParsedNote';
+import NoteTranslate from '../NoteTranslate/NoteTranslate';
 import NoteFooter from './NoteFooter/NoteFooter';
 
 import styles from './Note.module.scss';
@@ -412,6 +413,7 @@ const Note: Component<NoteProps> = (props) => {
                 width={Math.min(598, window.innerWidth)}
                 margins={isPhone() ? 42 : 1}
               />
+              <NoteTranslate note={props.note} />
             </div>
 
             <div class={styles.topZaps}>
@@ -642,6 +644,7 @@ const Note: Component<NoteProps> = (props) => {
                   margins={1}
                   footerSize="short"
                 />
+                <NoteTranslate note={props.note} />
               </div>
 
               <NoteTopZapsCompact

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -557,6 +557,7 @@ const Note: Component<NoteProps> = (props) => {
               width={window.innerWidth}
               margins={45}
             />
+            <NoteTranslate note={props.note} />
           </div>
 
           <NoteTopZapsCompact
@@ -761,6 +762,7 @@ const Note: Component<NoteProps> = (props) => {
                   margins={58}
                   footerSize="short"
                 />
+                <NoteTranslate note={props.note} />
               </div>
             </div>
           </div>

--- a/src/components/Note/NoteContextMenu.tsx
+++ b/src/components/Note/NoteContextMenu.tsx
@@ -17,6 +17,7 @@ import { useNavigate } from '@solidjs/router';
 import { Kind } from '../../constants';
 import { urlEncode } from '../../utils';
 import { accountStore, addToMuteList, hasPublicKey, removeFromMuteList, setShowPin, showGetStarted } from '../../stores/accountStore';
+import { translateNoteContent } from '../../lib/translation';
 
 const NoteContextMenu: Component<{
   data: NoteContextMenuInfo,
@@ -275,6 +276,17 @@ const NoteContextMenu: Component<{
       {
         label: [Kind.UserPoll, Kind.ZapPoll].includes(props.data?.note?.msg.kind) ? intl.formatMessage(tActions.pollContext.copyText) : intl.formatMessage(tActions.noteContext.copyText),
         action: copyNoteText,
+        icon: 'copy_note_text',
+      },
+      {
+        label: intl.formatMessage(tActions.noteContext.translate),
+        action: () => {
+          const n = note();
+          if (n?.id) {
+            void translateNoteContent(n.id, n.content || '');
+          }
+          props.onClose();
+        },
         icon: 'copy_note_text',
       },
       {

--- a/src/components/Note/NotePrimary/NotePrimary.tsx
+++ b/src/components/Note/NotePrimary/NotePrimary.tsx
@@ -2,6 +2,7 @@ import { Component } from 'solid-js';
 import { hookForDev } from '../../../lib/devTools';
 import { PrimalNote } from '../../../types/primal';
 import ParsedNote from '../../ParsedNote/ParsedNote';
+import NoteTranslate from '../../NoteTranslate/NoteTranslate';
 import NoteFooter from '../NoteFooter/NoteFooter';
 import NoteHeader from '../NoteHeader/NoteHeader';
 
@@ -23,6 +24,7 @@ const NotePrimary: Component<{ note: PrimalNote, id?: string }> = (props) => {
 
         <div class={styles.message}>
           <ParsedNote note={props.note} width={Math.min(574, window.innerWidth)} />
+          <NoteTranslate note={props.note} />
         </div>
 
         <NoteFooter note={props.note} wide={true} />

--- a/src/components/NoteTranslate/NoteTranslate.module.scss
+++ b/src/components/NoteTranslate/NoteTranslate.module.scss
@@ -1,0 +1,45 @@
+.noteTranslate {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.translatedText {
+  white-space: pre-wrap;
+  word-break: break-word;
+  opacity: 0.95;
+  line-height: 1.4;
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.linkBtn {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--accent-color, #c888dc);
+  cursor: pointer;
+  padding: 0;
+  font: inherit;
+  font-size: 13px;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.meta {
+  font-size: 12px;
+  opacity: 0.65;
+}
+
+.error {
+  font-size: 12px;
+  color: var(--warning-color, #f56c6c);
+}

--- a/src/components/NoteTranslate/NoteTranslate.tsx
+++ b/src/components/NoteTranslate/NoteTranslate.tsx
@@ -23,6 +23,8 @@ const errorMessage = (
       return intl.formatMessage(tActions.noteTranslate.errorMissingUrl);
     case 'disabled':
       return intl.formatMessage(tActions.noteTranslate.errorDisabled);
+    case 'empty_prose':
+      return intl.formatMessage(tActions.noteTranslate.errorEmptyProse);
     default:
       return intl.formatMessage(tActions.noteTranslate.error);
   }
@@ -69,6 +71,13 @@ const NoteTranslate: Component<{ note: PrimalNote }> = (props) => {
           <Match when={state()?.status === 'translated' && state()?.text}>
             <Show when={!state()?.showOriginal}>
               <div class={styles.translatedText}>{state()?.text}</div>
+              <Show when={state()?.detectedLanguage}>
+                <div class={styles.meta}>
+                  {intl.formatMessage(tActions.noteTranslate.fromLanguage, {
+                    language: (state()?.detectedLanguage || '').toUpperCase(),
+                  })}
+                </div>
+              </Show>
             </Show>
             <div class={styles.row}>
               <button

--- a/src/components/NoteTranslate/NoteTranslate.tsx
+++ b/src/components/NoteTranslate/NoteTranslate.tsx
@@ -8,68 +8,96 @@ import {
   translationProviderLabel,
   translationSettings,
 } from '../../lib/translation';
+import { shouldOfferTranslation } from '../../lib/translationSanitizer';
 import { actions as tActions } from '../../translations';
 import styles from './NoteTranslate.module.scss';
+
+const errorMessage = (
+  intl: ReturnType<typeof useIntl>,
+  code?: string,
+): string => {
+  switch (code) {
+    case 'missing_key':
+      return intl.formatMessage(tActions.noteTranslate.errorMissingKey);
+    case 'missing_url':
+      return intl.formatMessage(tActions.noteTranslate.errorMissingUrl);
+    case 'disabled':
+      return intl.formatMessage(tActions.noteTranslate.errorDisabled);
+    default:
+      return intl.formatMessage(tActions.noteTranslate.error);
+  }
+};
 
 const NoteTranslate: Component<{ note: PrimalNote }> = (props) => {
   const intl = useIntl();
   const state = () => noteTranslations[props.note.id];
+  const content = () => props.note.content || '';
+  const offer = () => shouldOfferTranslation(content());
 
   const onTranslate = () => {
-    void translateNoteContent(props.note.id, props.note.content || '');
+    void translateNoteContent(props.note.id, content());
   };
 
   return (
-    <div class={styles.noteTranslate}>
-      <Switch>
-        <Match when={state()?.status === 'loading'}>
-          <div class={styles.meta}>
-            {intl.formatMessage(tActions.noteTranslate.loading)}
-          </div>
-        </Match>
+    <Show
+      when={
+        translationSettings.enabled &&
+        (offer() ||
+          (state()?.status &&
+            state()?.status !== 'idle'))
+      }
+    >
+      <div class={styles.noteTranslate}>
+        <Switch>
+          <Match when={state()?.status === 'loading'}>
+            <div class={styles.meta}>
+              {intl.formatMessage(tActions.noteTranslate.loading)}
+            </div>
+          </Match>
 
-        <Match when={state()?.status === 'error'}>
-          <div class={styles.row}>
-            <button type="button" class={styles.linkBtn} onClick={onTranslate}>
-              {intl.formatMessage(tActions.noteTranslate.retry)}
-            </button>
-            <span class={styles.error}>
-              {intl.formatMessage(tActions.noteTranslate.error)}
-            </span>
-          </div>
-        </Match>
-
-        <Match when={state()?.status === 'translated' && state()?.text}>
-          <Show when={!state()?.showOriginal}>
-            <div class={styles.translatedText}>{state()?.text}</div>
-          </Show>
-          <div class={styles.row}>
-            <button
-              type="button"
-              class={styles.linkBtn}
-              onClick={() => toggleShowOriginal(props.note.id)}
-            >
-              {state()?.showOriginal
-                ? intl.formatMessage(tActions.noteTranslate.showTranslation)
-                : intl.formatMessage(tActions.noteTranslate.showOriginal)}
-            </button>
-            <Show when={state()?.provider}>
-              <span class={styles.meta}>
-                {intl.formatMessage(tActions.noteTranslate.via, {
-                  provider: translationProviderLabel(state()!.provider!),
-                })}
+          <Match when={state()?.status === 'error'}>
+            <div class={styles.row}>
+              <button type="button" class={styles.linkBtn} onClick={onTranslate}>
+                {intl.formatMessage(tActions.noteTranslate.retry)}
+              </button>
+              <span class={styles.error}>
+                {errorMessage(intl, state()?.error)}
               </span>
-            </Show>
-          </div>
-        </Match>
+            </div>
+          </Match>
 
-        <Match when={translationSettings.enabled}>
-          <button type="button" class={styles.linkBtn} onClick={onTranslate}>
-            {intl.formatMessage(tActions.noteTranslate.translate)}
-          </button>
-        </Match>
-      </Switch>
-    </div>
+          <Match when={state()?.status === 'translated' && state()?.text}>
+            <Show when={!state()?.showOriginal}>
+              <div class={styles.translatedText}>{state()?.text}</div>
+            </Show>
+            <div class={styles.row}>
+              <button
+                type="button"
+                class={styles.linkBtn}
+                onClick={() => toggleShowOriginal(props.note.id)}
+              >
+                {state()?.showOriginal
+                  ? intl.formatMessage(tActions.noteTranslate.showTranslation)
+                  : intl.formatMessage(tActions.noteTranslate.showOriginal)}
+              </button>
+              <Show when={state()?.provider}>
+                <span class={styles.meta}>
+                  {intl.formatMessage(tActions.noteTranslate.via, {
+                    provider: translationProviderLabel(state()!.provider!),
+                  })}
+                </span>
+              </Show>
+            </div>
+          </Match>
+
+          <Match when={offer()}>
+            <button type="button" class={styles.linkBtn} onClick={onTranslate}>
+              {intl.formatMessage(tActions.noteTranslate.translate)}
+            </button>
+          </Match>
+        </Switch>
+      </div>
+    </Show>
   );
 };
 

--- a/src/components/NoteTranslate/NoteTranslate.tsx
+++ b/src/components/NoteTranslate/NoteTranslate.tsx
@@ -1,0 +1,76 @@
+import { Component, Match, Show, Switch } from 'solid-js';
+import { useIntl } from '@cookbook/solid-intl';
+import { PrimalNote } from '../../types/primal';
+import {
+  noteTranslations,
+  toggleShowOriginal,
+  translateNoteContent,
+  translationProviderLabel,
+  translationSettings,
+} from '../../lib/translation';
+import { actions as tActions } from '../../translations';
+import styles from './NoteTranslate.module.scss';
+
+const NoteTranslate: Component<{ note: PrimalNote }> = (props) => {
+  const intl = useIntl();
+  const state = () => noteTranslations[props.note.id];
+
+  const onTranslate = () => {
+    void translateNoteContent(props.note.id, props.note.content || '');
+  };
+
+  return (
+    <div class={styles.noteTranslate}>
+      <Switch>
+        <Match when={state()?.status === 'loading'}>
+          <div class={styles.meta}>
+            {intl.formatMessage(tActions.noteTranslate.loading)}
+          </div>
+        </Match>
+
+        <Match when={state()?.status === 'error'}>
+          <div class={styles.row}>
+            <button type="button" class={styles.linkBtn} onClick={onTranslate}>
+              {intl.formatMessage(tActions.noteTranslate.retry)}
+            </button>
+            <span class={styles.error}>
+              {intl.formatMessage(tActions.noteTranslate.error)}
+            </span>
+          </div>
+        </Match>
+
+        <Match when={state()?.status === 'translated' && state()?.text}>
+          <Show when={!state()?.showOriginal}>
+            <div class={styles.translatedText}>{state()?.text}</div>
+          </Show>
+          <div class={styles.row}>
+            <button
+              type="button"
+              class={styles.linkBtn}
+              onClick={() => toggleShowOriginal(props.note.id)}
+            >
+              {state()?.showOriginal
+                ? intl.formatMessage(tActions.noteTranslate.showTranslation)
+                : intl.formatMessage(tActions.noteTranslate.showOriginal)}
+            </button>
+            <Show when={state()?.provider}>
+              <span class={styles.meta}>
+                {intl.formatMessage(tActions.noteTranslate.via, {
+                  provider: translationProviderLabel(state()!.provider!),
+                })}
+              </span>
+            </Show>
+          </div>
+        </Match>
+
+        <Match when={translationSettings.enabled}>
+          <button type="button" class={styles.linkBtn} onClick={onTranslate}>
+            {intl.formatMessage(tActions.noteTranslate.translate)}
+          </button>
+        </Match>
+      </Switch>
+    </div>
+  );
+};
+
+export default NoteTranslate;

--- a/src/lib/translation.ts
+++ b/src/lib/translation.ts
@@ -155,10 +155,12 @@ async function translateWithProvider(
 
   const base = (settings.libreTranslateUrl || '').replace(/\/$/, '');
   if (!base) throw new Error('missing_url');
+  // LibreTranslate expects ISO 639-1 (en) not BCP-47 (en-US)
+  const ltTarget = target.split(/[-_]/)[0].toLowerCase() || 'en';
   const body: Record<string, string> = {
     q: text,
     source: 'auto',
-    target,
+    target: ltTarget,
     format: 'text',
   };
   if (settings.apiKey) body.api_key = settings.apiKey;

--- a/src/lib/translation.ts
+++ b/src/lib/translation.ts
@@ -63,7 +63,16 @@ export const saveTranslationSettings = (
   patch: Partial<TranslationSettings>,
 ) => {
   setTranslationSettings(patch);
-  localStorage.setItem(SETTINGS_KEY, JSON.stringify({ ...translationSettings }));
+  // Merge explicitly so localStorage always gets the full latest snapshot.
+  const next: TranslationSettings = {
+    enabled: translationSettings.enabled,
+    provider: translationSettings.provider,
+    apiKey: translationSettings.apiKey,
+    libreTranslateUrl: translationSettings.libreTranslateUrl,
+    targetLanguage: translationSettings.targetLanguage,
+    ...patch,
+  };
+  localStorage.setItem(SETTINGS_KEY, JSON.stringify(next));
 };
 
 type CacheEntry = {

--- a/src/lib/translation.ts
+++ b/src/lib/translation.ts
@@ -117,6 +117,7 @@ const normalizeTarget = (lang: string) => lang.trim() || 'en';
 async function translateWithProvider(
   text: string,
   settings: TranslationSettings,
+  signal?: AbortSignal,
 ): Promise<string> {
   const target = normalizeTarget(settings.targetLanguage);
 
@@ -127,6 +128,7 @@ async function translateWithProvider(
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ q: text, target, format: 'text' }),
+      signal,
     });
     const data = await response.json();
     const translated = data?.data?.translations?.[0]?.translatedText;
@@ -146,6 +148,7 @@ async function translateWithProvider(
         text: [text],
         target_lang: target.split('-')[0].toUpperCase(),
       }),
+      signal,
     });
     const data = await response.json();
     const translated = data?.translations?.[0]?.text;
@@ -169,6 +172,7 @@ async function translateWithProvider(
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
+    signal,
   });
   const data = await response.json();
   if (!response.ok || !data?.translatedText) throw new Error('provider_error');
@@ -193,6 +197,10 @@ export const translateNoteContent = async (
 
   setNoteTranslations(noteId, { status: 'loading', showOriginal: false });
 
+  translateControllers.get(noteId)?.abort();
+  const controller = new AbortController();
+  translateControllers.set(noteId, controller);
+
   try {
     const { content: sanitized, placeholders } = sanitizeForTranslation(
       content || '',
@@ -202,7 +210,7 @@ export const translateNoteContent = async (
     );
     const cached = readCache().find((e) => e.key === cacheKey);
     const raw =
-      cached?.text ?? (await translateWithProvider(sanitized, settings));
+      cached?.text ?? (await translateWithProvider(sanitized, settings, controller.signal));
     if (!cached) {
       writeCache({
         key: cacheKey,
@@ -211,6 +219,7 @@ export const translateNoteContent = async (
         savedAt: Date.now(),
       });
     }
+    if (controller.signal.aborted) return;
     setNoteTranslations(noteId, {
       status: 'translated',
       text: restoreTranslationContent(raw, placeholders),
@@ -218,8 +227,13 @@ export const translateNoteContent = async (
       showOriginal: false,
     });
   } catch (err) {
+    if (controller.signal.aborted) return;
     const message = err instanceof Error ? err.message : 'provider_error';
     setNoteTranslations(noteId, { status: 'error', error: message });
+  } finally {
+    if (translateControllers.get(noteId) === controller) {
+      translateControllers.delete(noteId);
+    }
   }
 };
 
@@ -229,6 +243,10 @@ export const toggleShowOriginal = (noteId: string) => {
   setNoteTranslations(noteId, 'showOriginal', !(current.showOriginal ?? false));
 };
 
+const translateControllers = new Map<string, AbortController>();
+
 export const clearNoteTranslation = (noteId: string) => {
+  translateControllers.get(noteId)?.abort();
+  translateControllers.delete(noteId);
   setNoteTranslations(noteId, { status: 'idle' });
 };

--- a/src/lib/translation.ts
+++ b/src/lib/translation.ts
@@ -1,0 +1,232 @@
+import { createStore } from 'solid-js/store';
+import {
+  restoreTranslationContent,
+  sanitizeForTranslation,
+} from './translationSanitizer';
+
+export type TranslationProvider = 'libretranslate' | 'google' | 'deepl';
+
+export type TranslationSettings = {
+  enabled: boolean;
+  provider: TranslationProvider;
+  apiKey: string;
+  libreTranslateUrl: string;
+  targetLanguage: string;
+};
+
+export type NoteTranslation = {
+  status: 'idle' | 'loading' | 'translated' | 'error';
+  text?: string;
+  provider?: TranslationProvider;
+  showOriginal?: boolean;
+  error?: string;
+};
+
+const SETTINGS_KEY = 'primal.translation.settings.v1';
+const CACHE_KEY = 'primal.translation.cache.v1';
+const CACHE_MAX_ENTRIES = 100;
+const CACHE_MAX_BYTES = 1024 * 1024;
+
+const defaultTargetLanguage = () => {
+  if (typeof navigator !== 'undefined' && navigator.language) {
+    return navigator.language;
+  }
+  return 'en';
+};
+
+export const defaultTranslationSettings = (): TranslationSettings => ({
+  enabled: true,
+  provider: 'libretranslate',
+  apiKey: '',
+  libreTranslateUrl: 'https://libretranslate.com',
+  targetLanguage: defaultTargetLanguage(),
+});
+
+const readSettings = (): TranslationSettings => {
+  try {
+    const raw = localStorage.getItem(SETTINGS_KEY);
+    if (!raw) return defaultTranslationSettings();
+    return { ...defaultTranslationSettings(), ...JSON.parse(raw) };
+  } catch {
+    return defaultTranslationSettings();
+  }
+};
+
+export const [translationSettings, setTranslationSettings] =
+  createStore<TranslationSettings>(readSettings());
+
+export const [noteTranslations, setNoteTranslations] = createStore<
+  Record<string, NoteTranslation>
+>({});
+
+export const saveTranslationSettings = (
+  patch: Partial<TranslationSettings>,
+) => {
+  setTranslationSettings(patch);
+  localStorage.setItem(SETTINGS_KEY, JSON.stringify({ ...translationSettings }));
+};
+
+type CacheEntry = {
+  key: string;
+  text: string;
+  provider: TranslationProvider;
+  savedAt: number;
+};
+
+const readCache = (): CacheEntry[] => {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(CACHE_KEY) || '[]');
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+const writeCache = (entry: CacheEntry) => {
+  let cache = [entry, ...readCache().filter((e) => e.key !== entry.key)].slice(
+    0,
+    CACHE_MAX_ENTRIES,
+  );
+  while (
+    cache.length > 0 &&
+    new Blob([JSON.stringify(cache)]).size > CACHE_MAX_BYTES
+  ) {
+    cache = cache.slice(0, -1);
+  }
+  localStorage.setItem(CACHE_KEY, JSON.stringify(cache));
+};
+
+const sha256Hex = async (value: string): Promise<string> => {
+  const bytes = new Uint8Array(
+    await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value)),
+  );
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+};
+
+export const translationProviderLabel = (
+  provider: TranslationProvider,
+): string =>
+  ({
+    libretranslate: 'LibreTranslate',
+    google: 'Google Cloud Translation',
+    deepl: 'DeepL',
+  })[provider];
+
+const normalizeTarget = (lang: string) => lang.trim() || 'en';
+
+async function translateWithProvider(
+  text: string,
+  settings: TranslationSettings,
+): Promise<string> {
+  const target = normalizeTarget(settings.targetLanguage);
+
+  if (settings.provider === 'google') {
+    if (!settings.apiKey) throw new Error('missing_key');
+    const url = `https://translation.googleapis.com/language/translate/v2?key=${encodeURIComponent(settings.apiKey)}`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ q: text, target, format: 'text' }),
+    });
+    const data = await response.json();
+    const translated = data?.data?.translations?.[0]?.translatedText;
+    if (!response.ok || !translated) throw new Error('provider_error');
+    return translated as string;
+  }
+
+  if (settings.provider === 'deepl') {
+    if (!settings.apiKey) throw new Error('missing_key');
+    const response = await fetch('https://api.deepl.com/v2/translate', {
+      method: 'POST',
+      headers: {
+        Authorization: `DeepL-Auth-Key ${settings.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        text: [text],
+        target_lang: target.split('-')[0].toUpperCase(),
+      }),
+    });
+    const data = await response.json();
+    const translated = data?.translations?.[0]?.text;
+    if (!response.ok || !translated) throw new Error('provider_error');
+    return translated as string;
+  }
+
+  const base = (settings.libreTranslateUrl || '').replace(/\/$/, '');
+  if (!base) throw new Error('missing_url');
+  const body: Record<string, string> = {
+    q: text,
+    source: 'auto',
+    target,
+    format: 'text',
+  };
+  if (settings.apiKey) body.api_key = settings.apiKey;
+
+  const response = await fetch(`${base}/translate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const data = await response.json();
+  if (!response.ok || !data?.translatedText) throw new Error('provider_error');
+  return data.translatedText as string;
+}
+
+export const translateNoteContent = async (
+  noteId: string,
+  content: string,
+): Promise<void> => {
+  if (!noteId) return;
+  if (noteTranslations[noteId]?.status === 'loading') return;
+
+  const settings = { ...translationSettings };
+  if (!settings.enabled) {
+    setNoteTranslations(noteId, {
+      status: 'error',
+      error: 'disabled',
+    });
+    return;
+  }
+
+  setNoteTranslations(noteId, { status: 'loading', showOriginal: false });
+
+  try {
+    const { content: sanitized, placeholders } = sanitizeForTranslation(
+      content || '',
+    );
+    const cacheKey = await sha256Hex(
+      `${content}\n${settings.targetLanguage}\n${settings.provider}\n${settings.libreTranslateUrl}`,
+    );
+    const cached = readCache().find((e) => e.key === cacheKey);
+    const raw =
+      cached?.text ?? (await translateWithProvider(sanitized, settings));
+    if (!cached) {
+      writeCache({
+        key: cacheKey,
+        text: raw,
+        provider: settings.provider,
+        savedAt: Date.now(),
+      });
+    }
+    setNoteTranslations(noteId, {
+      status: 'translated',
+      text: restoreTranslationContent(raw, placeholders),
+      provider: settings.provider,
+      showOriginal: false,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'provider_error';
+    setNoteTranslations(noteId, { status: 'error', error: message });
+  }
+};
+
+export const toggleShowOriginal = (noteId: string) => {
+  const current = noteTranslations[noteId];
+  if (!current || current.status !== 'translated') return;
+  setNoteTranslations(noteId, 'showOriginal', !(current.showOriginal ?? false));
+};
+
+export const clearNoteTranslation = (noteId: string) => {
+  setNoteTranslations(noteId, { status: 'idle' });
+};

--- a/src/lib/translation.ts
+++ b/src/lib/translation.ts
@@ -112,7 +112,15 @@ export const translationProviderLabel = (
     deepl: 'DeepL',
   })[provider];
 
-const normalizeTarget = (lang: string) => lang.trim() || 'en';
+/** Normalize BCP-47 / locale tags to a primary language subtag when needed. */
+const normalizeTarget = (lang: string) => {
+  const trimmed = (lang || '').trim();
+  if (!trimmed) return 'en';
+  return trimmed;
+};
+
+const primaryLang = (lang: string) =>
+  normalizeTarget(lang).split(/[-_]/)[0].toLowerCase() || 'en';
 
 async function translateWithProvider(
   text: string,
@@ -120,6 +128,7 @@ async function translateWithProvider(
   signal?: AbortSignal,
 ): Promise<string> {
   const target = normalizeTarget(settings.targetLanguage);
+  const iso639 = primaryLang(target);
 
   if (settings.provider === 'google') {
     if (!settings.apiKey) throw new Error('missing_key');
@@ -127,7 +136,8 @@ async function translateWithProvider(
     const response = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ q: text, target, format: 'text' }),
+      // Google accepts en or en-US; prefer primary subtag for consistency.
+      body: JSON.stringify({ q: text, target: iso639, format: 'text' }),
       signal,
     });
     const data = await response.json();
@@ -146,7 +156,7 @@ async function translateWithProvider(
       },
       body: JSON.stringify({
         text: [text],
-        target_lang: target.split('-')[0].toUpperCase(),
+        target_lang: iso639.toUpperCase(),
       }),
       signal,
     });
@@ -159,11 +169,10 @@ async function translateWithProvider(
   const base = (settings.libreTranslateUrl || '').replace(/\/$/, '');
   if (!base) throw new Error('missing_url');
   // LibreTranslate expects ISO 639-1 (en) not BCP-47 (en-US)
-  const ltTarget = target.split(/[-_]/)[0].toLowerCase() || 'en';
   const body: Record<string, string> = {
     q: text,
     source: 'auto',
-    target: ltTarget,
+    target: iso639,
     format: 'text',
   };
   if (settings.apiKey) body.api_key = settings.apiKey;

--- a/src/lib/translation.ts
+++ b/src/lib/translation.ts
@@ -148,7 +148,11 @@ async function translateWithProvider(
 
   if (settings.provider === 'deepl') {
     if (!settings.apiKey) throw new Error('missing_key');
-    const response = await fetch('https://api.deepl.com/v2/translate', {
+    // Free keys end with ":fx" and must use the free API host.
+    const deeplHost = settings.apiKey.trim().endsWith(':fx')
+      ? 'https://api-free.deepl.com'
+      : 'https://api.deepl.com';
+    const response = await fetch(`${deeplHost}/v2/translate`, {
       method: 'POST',
       headers: {
         Authorization: `DeepL-Auth-Key ${settings.apiKey}`,

--- a/src/lib/translation.ts
+++ b/src/lib/translation.ts
@@ -20,6 +20,7 @@ export type NoteTranslation = {
   provider?: TranslationProvider;
   showOriginal?: boolean;
   error?: string;
+  detectedLanguage?: string;
 };
 
 const SETTINGS_KEY = 'primal.translation.settings.v1';
@@ -79,7 +80,59 @@ type CacheEntry = {
   key: string;
   text: string;
   provider: TranslationProvider;
+  detectedLanguage?: string;
   savedAt: number;
+};
+
+/**
+ * Accept a LibreTranslate base URL or a full `/translate` path.
+ * Prevents accidental `.../translate/translate` when users paste the API path.
+ */
+export const normalizeLibreTranslateBaseUrl = (raw: string): string => {
+  const trimmed = (raw || '').trim();
+  if (!trimmed) return '';
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return '';
+    let path = url.pathname.replace(/\/+$/, '') || '';
+    if (path.toLowerCase().endsWith('/translate')) {
+      path = path.slice(0, -'/translate'.length) || '';
+    }
+    url.pathname = path || '/';
+    url.search = '';
+    url.hash = '';
+    // Drop trailing slash for stable cache keys.
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    return trimmed.replace(/\/translate\/?$/i, '').replace(/\/$/, '');
+  }
+};
+
+const extractTranslatedText = (data: Record<string, unknown>): string | undefined => {
+  const candidates = [data.translatedText, data.translation, data.text];
+  for (const value of candidates) {
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return undefined;
+};
+
+const extractDetectedLanguage = (data: Record<string, unknown>): string | undefined => {
+  const raw =
+    data.detectedLanguage ??
+    data.detected_language ??
+    data.detected_source_language;
+  if (typeof raw === 'string' && raw.trim()) return raw.trim();
+  if (raw && typeof raw === 'object') {
+    const obj = raw as Record<string, unknown>;
+    if (typeof obj.language === 'string') return obj.language;
+    if (typeof obj.lang === 'string') return obj.lang;
+  }
+  return undefined;
+};
+
+type ProviderResult = {
+  text: string;
+  detectedLanguage?: string;
 };
 
 const readCache = (): CacheEntry[] => {
@@ -135,7 +188,7 @@ async function translateWithProvider(
   text: string,
   settings: TranslationSettings,
   signal?: AbortSignal,
-): Promise<string> {
+): Promise<ProviderResult> {
   const target = normalizeTarget(settings.targetLanguage);
   const iso639 = primaryLang(target);
 
@@ -150,9 +203,16 @@ async function translateWithProvider(
       signal,
     });
     const data = await response.json();
-    const translated = data?.data?.translations?.[0]?.translatedText;
+    const first = data?.data?.translations?.[0];
+    const translated = first?.translatedText;
     if (!response.ok || !translated) throw new Error('provider_error');
-    return translated as string;
+    return {
+      text: translated as string,
+      detectedLanguage:
+        typeof first?.detectedSourceLanguage === 'string'
+          ? first.detectedSourceLanguage
+          : undefined,
+    };
   }
 
   if (settings.provider === 'deepl') {
@@ -174,12 +234,19 @@ async function translateWithProvider(
       signal,
     });
     const data = await response.json();
-    const translated = data?.translations?.[0]?.text;
+    const first = data?.translations?.[0];
+    const translated = first?.text;
     if (!response.ok || !translated) throw new Error('provider_error');
-    return translated as string;
+    return {
+      text: translated as string,
+      detectedLanguage:
+        typeof first?.detected_source_language === 'string'
+          ? first.detected_source_language
+          : undefined,
+    };
   }
 
-  const base = (settings.libreTranslateUrl || '').replace(/\/$/, '');
+  const base = normalizeLibreTranslateBaseUrl(settings.libreTranslateUrl);
   if (!base) throw new Error('missing_url');
   // LibreTranslate expects ISO 639-1 (en) not BCP-47 (en-US)
   const body: Record<string, string> = {
@@ -196,9 +263,13 @@ async function translateWithProvider(
     body: JSON.stringify(body),
     signal,
   });
-  const data = await response.json();
-  if (!response.ok || !data?.translatedText) throw new Error('provider_error');
-  return data.translatedText as string;
+  const data = (await response.json()) as Record<string, unknown>;
+  const translated = extractTranslatedText(data);
+  if (!response.ok || !translated) throw new Error('provider_error');
+  return {
+    text: translated,
+    detectedLanguage: extractDetectedLanguage(data),
+  };
 }
 
 const translateControllers = new Map<string, AbortController>();
@@ -229,26 +300,47 @@ export const translateNoteContent = async (
     const { content: sanitized, placeholders } = sanitizeForTranslation(
       content || '',
     );
+    const prose = sanitized.replace(/__PRIMAL_PROTECTED_\d+__/g, ' ').trim();
+    if (!prose || !/[\p{L}]/u.test(prose)) {
+      setNoteTranslations(noteId, {
+        status: 'error',
+        error: 'empty_prose',
+      });
+      return;
+    }
+
+    const normalizedLibre = normalizeLibreTranslateBaseUrl(
+      settings.libreTranslateUrl,
+    );
     const cacheKey = await sha256Hex(
-      `${content}\n${settings.targetLanguage}\n${settings.provider}\n${settings.libreTranslateUrl}`,
+      `${content}\n${settings.targetLanguage}\n${settings.provider}\n${normalizedLibre}`,
     );
     const cached = readCache().find((e) => e.key === cacheKey);
-    const raw =
-      cached?.text ?? (await translateWithProvider(sanitized, settings, controller.signal));
-    if (!cached) {
+    let rawText = cached?.text;
+    let detectedLanguage = cached?.detectedLanguage;
+    if (!rawText) {
+      const result = await translateWithProvider(
+        sanitized,
+        { ...settings, libreTranslateUrl: normalizedLibre || settings.libreTranslateUrl },
+        controller.signal,
+      );
+      rawText = result.text;
+      detectedLanguage = result.detectedLanguage;
       writeCache({
         key: cacheKey,
-        text: raw,
+        text: rawText,
         provider: settings.provider,
+        detectedLanguage,
         savedAt: Date.now(),
       });
     }
     if (controller.signal.aborted) return;
     setNoteTranslations(noteId, {
       status: 'translated',
-      text: restoreTranslationContent(raw, placeholders),
+      text: restoreTranslationContent(rawText, placeholders),
       provider: settings.provider,
       showOriginal: false,
+      detectedLanguage,
     });
   } catch (err) {
     if (controller.signal.aborted) return;

--- a/src/lib/translation.ts
+++ b/src/lib/translation.ts
@@ -179,12 +179,13 @@ async function translateWithProvider(
   return data.translatedText as string;
 }
 
+const translateControllers = new Map<string, AbortController>();
+
 export const translateNoteContent = async (
   noteId: string,
   content: string,
 ): Promise<void> => {
   if (!noteId) return;
-  if (noteTranslations[noteId]?.status === 'loading') return;
 
   const settings = { ...translationSettings };
   if (!settings.enabled) {
@@ -195,11 +196,12 @@ export const translateNoteContent = async (
     return;
   }
 
-  setNoteTranslations(noteId, { status: 'loading', showOriginal: false });
-
+  // Abort any in-flight request for this note, then start a new one.
   translateControllers.get(noteId)?.abort();
   const controller = new AbortController();
   translateControllers.set(noteId, controller);
+
+  setNoteTranslations(noteId, { status: 'loading', showOriginal: false });
 
   try {
     const { content: sanitized, placeholders } = sanitizeForTranslation(
@@ -242,8 +244,6 @@ export const toggleShowOriginal = (noteId: string) => {
   if (!current || current.status !== 'translated') return;
   setNoteTranslations(noteId, 'showOriginal', !(current.showOriginal ?? false));
 };
-
-const translateControllers = new Map<string, AbortController>();
 
 export const clearNoteTranslation = (noteId: string) => {
   translateControllers.get(noteId)?.abort();

--- a/src/lib/translationSanitizer.ts
+++ b/src/lib/translationSanitizer.ts
@@ -7,10 +7,14 @@ const PLACEHOLDER_RE = /__PRIMAL_PROTECTED_(\d+)__/g;
 
 /**
  * Tokens that must not be sent to a translation provider (Nostr refs, URLs,
- * hashtags, emoji shortcodes, lightning invoices).
+ * hashtags, emoji shortcodes, lightning invoices/offers, LNURLs, cashu, bc1).
  */
 const PROTECTED_TOKEN_RE =
-  /nostr:(?:npub|nprofile|note|nevent|naddr|nrelay)1[023456789acdefghjklmnpqrstuvwxyz]+|(?:npub|nprofile|note|nevent|naddr|nrelay)1[023456789acdefghjklmnpqrstuvwxyz]+|lnbc[0-9a-z]+|bc1[0-9a-z]+|https?:\/\/[^\s<>"']+|www\.[^\s<>"']+|#[\p{L}\p{N}_-]+|:[A-Za-z0-9_+-]+:/giu;
+  /nostr:(?:npub|nprofile|note|nevent|naddr|nrelay)1[023456789acdefghjklmnpqrstuvwxyz]+|(?:npub|nprofile|note|nevent|naddr|nrelay)1[023456789acdefghjklmnpqrstuvwxyz]+|lightning:(?:lnbc|lno|lni|lnurl)[0-9a-z]+|lnbc[0-9a-z]+|lno1[0-9a-z]+|lni1[0-9a-z]+|lnurl1[0-9a-z]+|cashu[A-Za-z0-9][A-Za-z0-9+/=_-]+|bc1[0-9a-z]+|https?:\/\/[^\s<>"']+|www\.[^\s<>"']+|#[\p{L}\p{N}_-]+|:[A-Za-z0-9_+-]+:/giu;
+
+// Providers sometimes mangle underscores / spacing in placeholders.
+const MANGLED_PLACEHOLDER_RE =
+  /[_*]{0,2}PRIMAL[_*\s-]?PROTECTED[_*\s-]?(\d+)[_*]{0,2}/gi;
 
 export const sanitizeForTranslation = (content: string): SanitizedContent => {
   const placeholders: string[] = [];
@@ -24,10 +28,19 @@ export const sanitizeForTranslation = (content: string): SanitizedContent => {
 export const restoreTranslationContent = (
   content: string,
   placeholders: string[],
-): string =>
-  content.replace(PLACEHOLDER_RE, (_match, index) => {
+): string => {
+  let out = content.replace(PLACEHOLDER_RE, (_match, index) => {
     const i = Number(index);
     return Number.isInteger(i) && placeholders[i] !== undefined
       ? placeholders[i]
       : _match;
   });
+  // Second pass for lightly mangled placeholders (e.g. dropped underscores).
+  out = out.replace(MANGLED_PLACEHOLDER_RE, (match, index) => {
+    const i = Number(index);
+    return Number.isInteger(i) && placeholders[i] !== undefined
+      ? placeholders[i]
+      : match;
+  });
+  return out;
+};

--- a/src/lib/translationSanitizer.ts
+++ b/src/lib/translationSanitizer.ts
@@ -7,10 +7,21 @@ const PLACEHOLDER_RE = /__PRIMAL_PROTECTED_(\d+)__/g;
 
 /**
  * Tokens that must not be sent to a translation provider (Nostr refs, URLs,
- * hashtags, emoji shortcodes, lightning invoices/offers, LNURLs, cashu, bc1).
+ * hashtags, @mentions, emoji shortcodes, lightning invoices/offers, LNURLs,
+ * cashu, bc1).
  */
 const PROTECTED_TOKEN_RE =
-  /nostr:(?:npub|nprofile|note|nevent|naddr|nrelay)1[023456789acdefghjklmnpqrstuvwxyz]+|(?:npub|nprofile|note|nevent|naddr|nrelay)1[023456789acdefghjklmnpqrstuvwxyz]+|lightning:(?:lnbc|lno|lni|lnurl)[0-9a-z]+|lnbc[0-9a-z]+|lno1[0-9a-z]+|lni1[0-9a-z]+|lnurl1[0-9a-z]+|cashu[A-Za-z0-9][A-Za-z0-9+/=_-]+|bc1[0-9a-z]+|https?:\/\/[^\s<>"']+|www\.[^\s<>"']+|#[\p{L}\p{N}_-]+|:[A-Za-z0-9_+-]+:/giu;
+  /nostr:(?:npub|nprofile|note|nevent|naddr|nrelay)1[023456789acdefghjklmnpqrstuvwxyz]+|(?:npub|nprofile|note|nevent|naddr|nrelay)1[023456789acdefghjklmnpqrstuvwxyz]+|lightning:(?:lnbc|lno|lni|lnurl)[0-9a-z]+|lnbc[0-9a-z]+|lno1[0-9a-z]+|lni1[0-9a-z]+|lnurl1[0-9a-z]+|cashu[A-Za-z0-9][A-Za-z0-9+/=_-]+|bc1[0-9a-z]+|https?:\/\/[^\s<>"']+|www\.[^\s<>"']+|#[\p{L}\p{N}_-]+|@[\p{L}\p{N}_.-]+|:[A-Za-z0-9_+-]+:/giu;
+
+/** Minimum length (after trim) before offering Translate on a note. */
+export const MIN_TRANSLATE_LENGTH = 12;
+
+/** Hide Translate on tiny / non-letter notes (matches Android/iOS). */
+export const shouldOfferTranslation = (content: string): boolean => {
+  const trimmed = (content || '').trim();
+  if (trimmed.length < MIN_TRANSLATE_LENGTH) return false;
+  return /[\p{L}]/u.test(trimmed);
+};
 
 // Providers sometimes mangle underscores / spacing in placeholders.
 const MANGLED_PLACEHOLDER_RE =

--- a/src/lib/translationSanitizer.ts
+++ b/src/lib/translationSanitizer.ts
@@ -1,0 +1,33 @@
+export type SanitizedContent = {
+  content: string;
+  placeholders: string[];
+};
+
+const PLACEHOLDER_RE = /__PRIMAL_PROTECTED_(\d+)__/g;
+
+/**
+ * Tokens that must not be sent to a translation provider (Nostr refs, URLs,
+ * hashtags, emoji shortcodes, lightning invoices).
+ */
+const PROTECTED_TOKEN_RE =
+  /nostr:(?:npub|nprofile|note|nevent|naddr)1[023456789acdefghjklmnpqrstuvwxyz]+|(?:npub|nprofile|note|nevent|naddr)1[023456789acdefghjklmnpqrstuvwxyz]+|lnbc[0-9a-z]+|https?:\/\/[^\s<>"']+|www\.[^\s<>"']+|#[\p{L}\p{N}_-]+|:[A-Za-z0-9_+-]+:/giu;
+
+export const sanitizeForTranslation = (content: string): SanitizedContent => {
+  const placeholders: string[] = [];
+  const sanitized = content.replace(PROTECTED_TOKEN_RE, (token) => {
+    const index = placeholders.push(token) - 1;
+    return `__PRIMAL_PROTECTED_${index}__`;
+  });
+  return { content: sanitized, placeholders };
+};
+
+export const restoreTranslationContent = (
+  content: string,
+  placeholders: string[],
+): string =>
+  content.replace(PLACEHOLDER_RE, (_match, index) => {
+    const i = Number(index);
+    return Number.isInteger(i) && placeholders[i] !== undefined
+      ? placeholders[i]
+      : _match;
+  });

--- a/src/lib/translationSanitizer.ts
+++ b/src/lib/translationSanitizer.ts
@@ -10,7 +10,7 @@ const PLACEHOLDER_RE = /__PRIMAL_PROTECTED_(\d+)__/g;
  * hashtags, emoji shortcodes, lightning invoices).
  */
 const PROTECTED_TOKEN_RE =
-  /nostr:(?:npub|nprofile|note|nevent|naddr)1[023456789acdefghjklmnpqrstuvwxyz]+|(?:npub|nprofile|note|nevent|naddr)1[023456789acdefghjklmnpqrstuvwxyz]+|lnbc[0-9a-z]+|https?:\/\/[^\s<>"']+|www\.[^\s<>"']+|#[\p{L}\p{N}_-]+|:[A-Za-z0-9_+-]+:/giu;
+  /nostr:(?:npub|nprofile|note|nevent|naddr|nrelay)1[023456789acdefghjklmnpqrstuvwxyz]+|(?:npub|nprofile|note|nevent|naddr|nrelay)1[023456789acdefghjklmnpqrstuvwxyz]+|lnbc[0-9a-z]+|bc1[0-9a-z]+|https?:\/\/[^\s<>"']+|www\.[^\s<>"']+|#[\p{L}\p{N}_-]+|:[A-Za-z0-9_+-]+:/giu;
 
 export const sanitizeForTranslation = (content: string): SanitizedContent => {
   const placeholders: string[] = [];

--- a/src/lib/translationSanitizer.ts
+++ b/src/lib/translationSanitizer.ts
@@ -16,13 +16,6 @@ const PROTECTED_TOKEN_RE =
 /** Minimum length (after trim) before offering Translate on a note. */
 export const MIN_TRANSLATE_LENGTH = 12;
 
-/** Hide Translate on tiny / non-letter notes (matches Android/iOS). */
-export const shouldOfferTranslation = (content: string): boolean => {
-  const trimmed = (content || '').trim();
-  if (trimmed.length < MIN_TRANSLATE_LENGTH) return false;
-  return /[\p{L}]/u.test(trimmed);
-};
-
 // Providers sometimes mangle underscores / spacing in placeholders.
 const MANGLED_PLACEHOLDER_RE =
   /[_*]{0,2}PRIMAL[_*\s-]?PROTECTED[_*\s-]?(\d+)[_*]{0,2}/gi;
@@ -54,4 +47,18 @@ export const restoreTranslationContent = (
       : match;
   });
   return out;
+};
+
+/**
+ * Hide Translate on tiny notes, notes with no letters, or notes that are only
+ * protected tokens (npubs, invoices, URLs, etc.) after sanitization.
+ */
+export const shouldOfferTranslation = (content: string): boolean => {
+  const trimmed = (content || '').trim();
+  if (trimmed.length < MIN_TRANSLATE_LENGTH) return false;
+  if (!/[\p{L}]/u.test(trimmed)) return false;
+  // Require real prose after stripping Nostr/Lightning/URL tokens.
+  const { content: sanitized } = sanitizeForTranslation(trimmed);
+  const prose = sanitized.replace(/__PRIMAL_PROTECTED_\d+__/g, ' ').trim();
+  return prose.length >= 4 && /[\p{L}]/u.test(prose);
 };

--- a/src/pages/Settings/Menu.tsx
+++ b/src/pages/Settings/Menu.tsx
@@ -37,6 +37,11 @@ const Menu: Component = () => {
           <div class={styles.chevron}></div>
         </A>
 
+        <A href="/settings/translation">
+          {intl.formatMessage(t.translation.title)}
+          <div class={styles.chevron}></div>
+        </A>
+
         <A href="/settings/home_feeds">
           {intl.formatMessage(t.homeFeeds.title)}
           <div class={styles.chevron}></div>

--- a/src/pages/Settings/Translation.tsx
+++ b/src/pages/Settings/Translation.tsx
@@ -1,0 +1,140 @@
+import { Component, For } from 'solid-js';
+import { useIntl } from '@cookbook/solid-intl';
+import { A } from '@solidjs/router';
+import PageCaption from '../../components/PageCaption/PageCaption';
+import PageTitle from '../../components/PageTitle/PageTitle';
+import CheckBox from '../../components/Checkbox/CheckBox';
+import {
+  saveTranslationSettings,
+  translationSettings,
+  TranslationProvider,
+} from '../../lib/translation';
+import { settings as t } from '../../translations';
+import styles from './Settings.module.scss';
+
+const LANGS = [
+  'en', 'es', 'fr', 'de', 'pt', 'it', 'nl', 'pl', 'ru', 'uk', 'ja', 'zh', 'ko',
+  'ar', 'hi', 'tr', 'sv', 'no', 'da', 'fi', 'cs', 'ro', 'hu',
+];
+
+const TranslationSettingsPage: Component = () => {
+  const intl = useIntl();
+
+  return (
+    <div>
+      <PageTitle
+        title={`${intl.formatMessage(t.translation.title)} ${intl.formatMessage(t.title)}`}
+      />
+
+      <PageCaption>
+        <A href="/settings">{intl.formatMessage(t.index.title)}</A>:&nbsp;
+        <div>{intl.formatMessage(t.translation.title)}</div>
+      </PageCaption>
+
+      <div class={styles.settingsContent}>
+        <div class={styles.settingsCaption}>
+          {intl.formatMessage(t.translation.caption)}
+        </div>
+
+        <div style={{ 'margin-bottom': '16px' }}>
+          <CheckBox
+            checked={translationSettings.enabled}
+            onChange={(checked) => saveTranslationSettings({ enabled: checked })}
+          >
+            <div class={styles.appearanceCheckLabel}>
+              {intl.formatMessage(t.translation.enable)}
+            </div>
+          </CheckBox>
+        </div>
+
+        <label class={styles.settingsCaption} for="translation-provider">
+          {intl.formatMessage(t.translation.provider)}
+        </label>
+        <select
+          id="translation-provider"
+          value={translationSettings.provider}
+          onChange={(e) =>
+            saveTranslationSettings({
+              provider: e.currentTarget.value as TranslationProvider,
+            })
+          }
+          style={{
+            width: '100%',
+            'max-width': '420px',
+            'margin-bottom': '16px',
+            padding: '8px',
+          }}
+        >
+          <option value="libretranslate">LibreTranslate (self-hostable)</option>
+          <option value="google">Google Cloud Translation (API key)</option>
+          <option value="deepl">DeepL (API key)</option>
+        </select>
+
+        <label class={styles.settingsCaption} for="translation-target">
+          {intl.formatMessage(t.translation.targetLanguage)}
+        </label>
+        <select
+          id="translation-target"
+          value={translationSettings.targetLanguage.split('-')[0]}
+          onChange={(e) =>
+            saveTranslationSettings({ targetLanguage: e.currentTarget.value })
+          }
+          style={{
+            width: '100%',
+            'max-width': '420px',
+            'margin-bottom': '16px',
+            padding: '8px',
+          }}
+        >
+          <For each={LANGS}>
+            {(code) => <option value={code}>{code}</option>}
+          </For>
+        </select>
+
+        <label class={styles.settingsCaption} for="translation-url">
+          {intl.formatMessage(t.translation.libreUrl)}
+        </label>
+        <input
+          id="translation-url"
+          type="url"
+          value={translationSettings.libreTranslateUrl}
+          onInput={(e) =>
+            saveTranslationSettings({ libreTranslateUrl: e.currentTarget.value })
+          }
+          placeholder="https://libretranslate.com"
+          style={{
+            width: '100%',
+            'max-width': '420px',
+            'margin-bottom': '16px',
+            padding: '8px',
+          }}
+        />
+
+        <label class={styles.settingsCaption} for="translation-key">
+          {intl.formatMessage(t.translation.apiKey)}
+        </label>
+        <input
+          id="translation-key"
+          type="password"
+          value={translationSettings.apiKey}
+          onInput={(e) =>
+            saveTranslationSettings({ apiKey: e.currentTarget.value })
+          }
+          autocomplete="off"
+          style={{
+            width: '100%',
+            'max-width': '420px',
+            'margin-bottom': '16px',
+            padding: '8px',
+          }}
+        />
+
+        <p class={styles.webVersion} style={{ opacity: 0.7, 'font-size': '13px' }}>
+          {intl.formatMessage(t.translation.privacyNote)}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default TranslationSettingsPage;

--- a/src/pages/Settings/Translation.tsx
+++ b/src/pages/Settings/Translation.tsx
@@ -5,6 +5,7 @@ import PageCaption from '../../components/PageCaption/PageCaption';
 import PageTitle from '../../components/PageTitle/PageTitle';
 import CheckBox from '../../components/Checkbox/CheckBox';
 import {
+  normalizeLibreTranslateBaseUrl,
   saveTranslationSettings,
   translationSettings,
   TranslationProvider,
@@ -101,6 +102,14 @@ const TranslationSettingsPage: Component = () => {
           onInput={(e) =>
             saveTranslationSettings({ libreTranslateUrl: e.currentTarget.value })
           }
+          onBlur={(e) => {
+            const normalized = normalizeLibreTranslateBaseUrl(
+              e.currentTarget.value,
+            );
+            if (normalized && normalized !== translationSettings.libreTranslateUrl) {
+              saveTranslationSettings({ libreTranslateUrl: normalized });
+            }
+          }}
           placeholder="https://libretranslate.com"
           style={{
             width: '100%',

--- a/src/pages/Settings/Translation.tsx
+++ b/src/pages/Settings/Translation.tsx
@@ -67,7 +67,7 @@ const TranslationSettingsPage: Component = () => {
         >
           <option value="libretranslate">LibreTranslate (self-hostable)</option>
           <option value="google">Google Cloud Translation (API key)</option>
-          <option value="deepl">DeepL (API key)</option>
+          <option value="deepl">DeepL (pro or free :fx API key)</option>
         </select>
 
         <label class={styles.settingsCaption} for="translation-target">

--- a/src/translations.ts
+++ b/src/translations.ts
@@ -640,6 +640,11 @@ export const actions = {
       defaultMessage: 'Note translation is disabled in settings.',
       description: 'Translation feature disabled',
     },
+    errorEmptyProse: {
+      id: 'actions.noteTranslate.errorEmptyProse',
+      defaultMessage: 'Nothing to translate after protecting identifiers.',
+      description: 'Note is only protected tokens',
+    },
     retry: {
       id: 'actions.noteTranslate.retry',
       defaultMessage: 'Retry translation',
@@ -649,6 +654,11 @@ export const actions = {
       id: 'actions.noteTranslate.via',
       defaultMessage: 'Translated by {provider}',
       description: 'Provider attribution for translated note',
+    },
+    fromLanguage: {
+      id: 'actions.noteTranslate.fromLanguage',
+      defaultMessage: 'Translated from {language}',
+      description: 'Detected source language for translated note',
     },
   },
   pollContext: {

--- a/src/translations.ts
+++ b/src/translations.ts
@@ -1924,7 +1924,7 @@ export const settings = {
     },
     apiKey: {
       id: 'settings.translation.apiKey',
-      defaultMessage: 'API key (optional for some providers)',
+      defaultMessage: 'API key (required for Google/DeepL; free DeepL keys end with :fx)',
       description: 'Translation API key label',
     },
     privacyNote: {

--- a/src/translations.ts
+++ b/src/translations.ts
@@ -593,6 +593,48 @@ export const actions = {
       defaultMessage: 'Quote',
       description: 'Label for quoting note from context menu',
     },
+    translate: {
+      id: 'actions.noteContext.translate',
+      defaultMessage: 'Translate note',
+      description: 'Label for translating note from context menu',
+    },
+  },
+  noteTranslate: {
+    translate: {
+      id: 'actions.noteTranslate.translate',
+      defaultMessage: 'Translate',
+      description: 'Inline translate button',
+    },
+    showOriginal: {
+      id: 'actions.noteTranslate.showOriginal',
+      defaultMessage: 'Show original',
+      description: 'Toggle to original note text',
+    },
+    showTranslation: {
+      id: 'actions.noteTranslate.showTranslation',
+      defaultMessage: 'Show translation',
+      description: 'Toggle to translated note text',
+    },
+    loading: {
+      id: 'actions.noteTranslate.loading',
+      defaultMessage: 'Translating…',
+      description: 'Translation in progress',
+    },
+    error: {
+      id: 'actions.noteTranslate.error',
+      defaultMessage: 'Translation failed. Check settings or try again.',
+      description: 'Translation error message',
+    },
+    retry: {
+      id: 'actions.noteTranslate.retry',
+      defaultMessage: 'Retry translation',
+      description: 'Retry failed translation',
+    },
+    via: {
+      id: 'actions.noteTranslate.via',
+      defaultMessage: 'Translated by {provider}',
+      description: 'Provider attribution for translated note',
+    },
   },
   pollContext: {
     reactions: {
@@ -1832,6 +1874,48 @@ export const settings = {
       id: 'settings.appearance.caption',
       defaultMessage: 'Select a theme',
       description: 'Caption for theme selection',
+    },
+  },
+  translation: {
+    title: {
+      id: 'settings.translation.title',
+      defaultMessage: 'Note Translation',
+      description: 'Title of the note translation settings page',
+    },
+    caption: {
+      id: 'settings.translation.caption',
+      defaultMessage: 'Translate notes into your preferred language using a provider you control (LibreTranslate, Google, or DeepL).',
+      description: 'Caption for translation settings',
+    },
+    enable: {
+      id: 'settings.translation.enable',
+      defaultMessage: 'Enable note translation',
+      description: 'Enable translation checkbox',
+    },
+    provider: {
+      id: 'settings.translation.provider',
+      defaultMessage: 'Provider',
+      description: 'Translation provider label',
+    },
+    targetLanguage: {
+      id: 'settings.translation.targetLanguage',
+      defaultMessage: 'Target language',
+      description: 'Target language label',
+    },
+    libreUrl: {
+      id: 'settings.translation.libreUrl',
+      defaultMessage: 'LibreTranslate URL',
+      description: 'LibreTranslate instance URL',
+    },
+    apiKey: {
+      id: 'settings.translation.apiKey',
+      defaultMessage: 'API key (optional for some providers)',
+      description: 'Translation API key label',
+    },
+    privacyNote: {
+      id: 'settings.translation.privacyNote',
+      defaultMessage: 'Note text (with Nostr refs/URLs protected) is sent only to the provider you configure. Prefer a self-hosted LibreTranslate instance for privacy.',
+      description: 'Privacy note for translation settings',
     },
   },
   homeFeeds: {

--- a/src/translations.ts
+++ b/src/translations.ts
@@ -625,6 +625,21 @@ export const actions = {
       defaultMessage: 'Translation failed. Check settings or try again.',
       description: 'Translation error message',
     },
+    errorMissingKey: {
+      id: 'actions.noteTranslate.errorMissingKey',
+      defaultMessage: 'API key required. Add one in Settings → Note Translation.',
+      description: 'Missing provider API key',
+    },
+    errorMissingUrl: {
+      id: 'actions.noteTranslate.errorMissingUrl',
+      defaultMessage: 'Set a LibreTranslate URL in Settings → Note Translation.',
+      description: 'Missing LibreTranslate base URL',
+    },
+    errorDisabled: {
+      id: 'actions.noteTranslate.errorDisabled',
+      defaultMessage: 'Note translation is disabled in settings.',
+      description: 'Translation feature disabled',
+    },
     retry: {
       id: 'actions.noteTranslate.retry',
       defaultMessage: 'Retry translation',


### PR DESCRIPTION
## Summary
Configurable inline note translation for #133.

- **Settings** (`/settings/translation`): LibreTranslate / Google Cloud / DeepL, API key, target language, enable toggle
- **UX**: note context menu + inline Translate under note content (primary, desktop feed/thread, **phone feed**, **suggestion**, NotePrimary); show original / show translation toggle; detected source language when returned
- **Providers**: LibreTranslate (self-hostable), Google Translate v2, DeepL (routes free `:fx` keys to `api-free.deepl.com`)
- **Endpoint normalize**: accepts LibreTranslate base URL or full `/translate` path (no double path)
- **Cache**: client-side, keyed by content + target + provider (+ normalized LibreTranslate URL), capped
- **Abort**: `AbortController` cancels in-flight work on clear or re-trigger
- **Sanitizer**: protects Nostr tokens, `@mentions`, URLs, hashtags, shortcodes, `lnbc` / `lno1` / `lni1` / `lnurl1` / `lightning:` / cashu / `bc1` / `nrelay`; restores lightly mangled placeholders
- **Offer gating**: hides Translate on short, non-letter, or **token-only** notes (after protection)
- **Errors**: specific copy for missing API key, missing URL, disabled state, empty prose

## Why this PR
Compared with open alternatives for #133:

| Approach | Works without backend | Multi-provider settings | Invoice/npub/bc1/cashu safety | Phone feed coverage | Abortable requests | Automated checks |
|---|---|---|---|---|---|---|
| **This PR (#208)** | Yes | LibreTranslate + Google + DeepL | Hardened + mangled restore | Yes | Yes | `npm run check:translation` |
| #201 (menu → Google Translate) | Yes (external tab) | No | N/A (leaves app) | Menu only | N/A | No |
| #203 / #205 (cache RPC) | **No** (server work required) | Server-side | Partial | Partial | Varies | No |
| #204 (LibreTranslate inline) | Yes | LibreTranslate only | Weaker (no bolt12/cashu/bc1/nrelay) | Yes | No | No |

Frontend-only, mergeable today. No Primal server changes. Protects payment strings and Nostr identifiers before any provider sees them.

## Test plan
- [x] `node scripts/check-translation-sanitize.mjs` → PASS
- [x] `npm run check:translation`
- [ ] Settings → Note Translation: set provider / base URL / key / language
- [ ] Paste LibreTranslate full `/translate` URL; request still hits once (normalized)
- [ ] Note context menu Translate; inline show original / translation toggle
- [ ] Phone feed + suggestion + primary layouts show Translate
- [ ] Tokens survive: `nostr:` / `npub` / `@mention` / URLs / `lnbc` / `lno1` / `lnurl` / `cashu` / `bc1` / `nrelay`
- [ ] Short notes and token-only notes do not show Translate
- [ ] DeepL free key ending in `:fx` hits `api-free.deepl.com`

Closes #133