### PR TITLE
Fix key handling: fail on missing nsec, correct generateKeys, use uuidv4 for non-secret ids

### DIFF
--- a/src/components/ArticleHighlight/ArticleHighlightActionMenu.tsx
+++ b/src/components/ArticleHighlight/ArticleHighlightActionMenu.tsx
@@ -3,7 +3,7 @@ import { Component, Match, Show, Switch } from 'solid-js';
 import { Kind } from '../../constants';
 import { hookForDev } from '../../lib/devTools';
 import { removeHighlight, sendHighlight } from '../../lib/highlights';
-import { generatePrivateKey } from '../../lib/nTools';
+import { uuidv4 } from '../../utils';
 import { NostrRelaySignedEvent, PrimalArticle, } from '../../types/primal';
 
 import styles from './ArticleHighlight.module.scss';
@@ -120,7 +120,7 @@ const ArticleHighlightActionMenu: Component<{
       const { content, context } = generateContentAndContext(props.selection);
 
       const highlight = {
-        id: `${generatePrivateKey()}`,
+        id: uuidv4(),
         kind: Kind.Highlight,
         context,
         content,
@@ -151,7 +151,7 @@ const ArticleHighlightActionMenu: Component<{
       const context = (props.highlight.tags.find((t: string[]) => t[0] === 'context') || [])[1];
 
       const highlight = {
-        id: `${generatePrivateKey()}`,
+        id: uuidv4(),
         kind: Kind.Highlight,
         context,
         content,

--- a/src/components/DirectMessages/DirectMessageParsedContent.tsx
+++ b/src/components/DirectMessages/DirectMessageParsedContent.tsx
@@ -9,12 +9,11 @@ import { useDMContext } from '../../contexts/DMContext';
 import { A } from '@solidjs/router';
 import { useAppContext } from '../../contexts/AppContext';
 import { decodeIdentifier, hexToNpub } from '../../lib/keys';
-import { isDev } from '../../utils';
+import { isDev, uuidv4 } from '../../utils';
 import { hashtagCharsRegex, Kind, linebreakRegex, lnUnifiedRegex, noteRegex, specialCharsRegex, urlExtractRegex } from '../../constants';
 import { createStore } from 'solid-js/store';
 import { NoteContent } from '../ParsedNote/ParsedNote';
 import { isInterpunction, isUrl, isImage, isMp4Video, isOggVideo, isWebmVideo, isYouTube, isSpotify, isTwitch, isMixCloud, isSoundCloud, isAppleMusic, isWavelake, getLinkPreview, isNoteMention, isUserMention, isAddrMention, isTagMention, isHashtag, isCustomEmoji, isUnitifedLnAddress, isLnbc, is3gppVideo } from '../../lib/notes';
-import { generatePrivateKey } from '../../lib/nTools';
 import { useMediaContext } from '../../contexts/MediaContext';
 import NoteImage from '../NoteImage/NoteImage';
 import { getMediaUrl as getMediaUrlDefault } from "../../lib/media";
@@ -392,7 +391,7 @@ const DirectMessageParsedContent: Component<{
   const renderImage = (item: NoteContent, index?: number) => {
 
     const groupCount = item.tokens.length;
-    const imageGroup = generatePrivateKey();
+    const imageGroup = uuidv4();
 
     // Remove bottom margin if media is the last thing in the note
     const lastClass = index === content.length-1 ?

--- a/src/components/LiveVideo/ChatMessage.tsx
+++ b/src/components/LiveVideo/ChatMessage.tsx
@@ -9,12 +9,11 @@ import { useDMContext } from '../../contexts/DMContext';
 import { A } from '@solidjs/router';
 import { useAppContext } from '../../contexts/AppContext';
 import { decodeIdentifier, hexToNpub } from '../../lib/keys';
-import { isDev, urlEncode } from '../../utils';
+import { isDev, urlEncode, uuidv4 } from '../../utils';
 import { hashtagCharsRegex, Kind, linebreakRegex, lnUnifiedRegex, noteRegex, specialCharsRegex, urlExtractRegex } from '../../constants';
 import { createStore } from 'solid-js/store';
 import { NoteContent } from '../ParsedNote/ParsedNote';
 import { isInterpunction, isUrl, isImage, isMp4Video, isOggVideo, isWebmVideo, isYouTube, isSpotify, isTwitch, isMixCloud, isSoundCloud, isAppleMusic, isWavelake, getLinkPreview, isNoteMention, isUserMention, isAddrMention, isTagMention, isHashtag, isCustomEmoji, isUnitifedLnAddress, isLnbc, is3gppVideo } from '../../lib/notes';
-import { generatePrivateKey } from '../../lib/nTools';
 import { useMediaContext } from '../../contexts/MediaContext';
 import NoteImage from '../NoteImage/NoteImage';
 import { getMediaUrl as getMediaUrlDefault } from "../../lib/media";
@@ -388,7 +387,7 @@ const ChatMessage: Component<{
   const renderImage = (item: NoteContent, index?: number) => {
 
     const groupCount = item.tokens.length;
-    const imageGroup = generatePrivateKey();
+    const imageGroup = uuidv4();
 
     // Remove bottom margin if media is the last thing in the note
     const lastClass = index === content.length-1 ?

--- a/src/components/NostrImage/NostrImage.tsx
+++ b/src/components/NostrImage/NostrImage.tsx
@@ -1,6 +1,6 @@
 import { Component, createEffect, createSignal, JSX,  JSXElement,  onMount, Show } from "solid-js";
 import styles from "./NostrImage.module.scss";
-import { generatePrivateKey } from "../../lib/nTools";
+import { uuidv4 } from "../../utils";
 import { MediaVariant, NostrImageContent, NostrUserContent } from "../../types/primal";
 import { useAppContext } from "../../contexts/AppContext";
 
@@ -15,7 +15,7 @@ const NostrImage: Component<{
   event: NostrImageContent,
 }> = (props) => {
   const app = useAppContext();
-  const imgId = generatePrivateKey();
+  const imgId = uuidv4();
 
   let imgVirtual: HTMLImageElement | undefined;
   let imgWrapper: HTMLDivElement | undefined;

--- a/src/components/NoteImage/NoteImage.tsx
+++ b/src/components/NoteImage/NoteImage.tsx
@@ -1,6 +1,6 @@
 import { Component, createEffect, createSignal, JSX,  JSXElement,  onMount, Show } from "solid-js";
 import styles from "./NoteImage.module.scss";
-import { generatePrivateKey } from "../../lib/nTools";
+import { uuidv4 } from "../../utils";
 import { MediaVariant } from "../../types/primal";
 import { useAppContext } from "../../contexts/AppContext";
 import { cacheImages, isImageCached } from "../../lib/cache";
@@ -27,7 +27,7 @@ const NoteImage: Component<{
   isGallery?: boolean,
 }> = (props) => {
   const app = useAppContext();
-  const imgId = generatePrivateKey();
+  const imgId = uuidv4();
 
   let imgVirtual: HTMLImageElement | undefined;
   let imgActual: HTMLImageElement | undefined;

--- a/src/components/NoteImage/NoteImageSmall.tsx
+++ b/src/components/NoteImage/NoteImageSmall.tsx
@@ -1,6 +1,6 @@
 import { Component, createEffect, createSignal, JSX,  JSXElement,  onMount, Show } from "solid-js";
 import styles from "./NoteImage.module.scss";
-import { generatePrivateKey } from "../../lib/nTools";
+import { uuidv4 } from "../../utils";
 import { MediaVariant } from "../../types/primal";
 import { useAppContext } from "../../contexts/AppContext";
 
@@ -23,7 +23,7 @@ const NoteImageSmall: Component<{
   authorPk?: string,
 }> = (props) => {
   const app = useAppContext();
-  const imgId = generatePrivateKey();
+  const imgId = uuidv4();
 
   let imgVirtual: HTMLImageElement | undefined;
   let imgActual: HTMLImageElement | undefined;

--- a/src/components/ParsedNote/ParsedNote.tsx
+++ b/src/components/ParsedNote/ParsedNote.tsx
@@ -50,7 +50,7 @@ import {
 } from '../../types/primal';
 
 import styles from './ParsedNote.module.scss';
-import { nip19, generatePrivateKey } from '../../lib/nTools';
+import { nip19 } from '../../lib/nTools';
 import LinkPreview from '../LinkPreview/LinkPreview';
 import MentionedUserLink from '../Note/MentionedUserLink/MentionedUserLink';
 import { useMediaContext } from '../../contexts/MediaContext';
@@ -84,7 +84,7 @@ import { APP_ID } from '../../App';
 import { getEvents } from '../../lib/feed';
 import { subsTo } from '../../sockets';
 import ProfileNoteZap from '../ProfileNoteZap/ProfileNoteZap';
-import { parseBolt11 } from '../../utils';
+import { parseBolt11, uuidv4 } from '../../utils';
 import SimpleArticlePreview from '../ArticlePreview/SimpleArticlePreview';
 import NostrImage from '../NostrImage/NostrImage';
 import { StreamingData } from '../../lib/streaming';
@@ -656,7 +656,7 @@ const ParsedNote: Component<{
   const renderImage = (item: NoteContent, index?: number) => {
 
     const groupCount = item.tokens.length;
-    const imageGroup = generatePrivateKey();
+    const imageGroup = uuidv4();
 
     const imageError = (event: any) => {
       // const image = event.target;

--- a/src/components/ParsedNote/ParsedPoll.tsx
+++ b/src/components/ParsedNote/ParsedPoll.tsx
@@ -51,7 +51,7 @@ import {
 } from '../../types/primal';
 
 import styles from './ParsedNote.module.scss';
-import { nip19, generatePrivateKey } from '../../lib/nTools';
+import { nip19 } from '../../lib/nTools';
 import LinkPreview from '../LinkPreview/LinkPreview';
 import MentionedUserLink from '../Note/MentionedUserLink/MentionedUserLink';
 import { useMediaContext } from '../../contexts/MediaContext';
@@ -85,7 +85,7 @@ import { APP_ID } from '../../App';
 import { getEvents } from '../../lib/feed';
 import { subsTo } from '../../sockets';
 import ProfileNoteZap from '../ProfileNoteZap/ProfileNoteZap';
-import { parseBolt11 } from '../../utils';
+import { parseBolt11, uuidv4 } from '../../utils';
 import SimpleArticlePreview from '../ArticlePreview/SimpleArticlePreview';
 import NostrImage from '../NostrImage/NostrImage';
 import { StreamingData } from '../../lib/streaming';
@@ -650,7 +650,7 @@ const ParsedNote: Component<{
   const renderImage = (item: NoteContent, index?: number) => {
 
     const groupCount = item.tokens.length;
-    const imageGroup = generatePrivateKey();
+    const imageGroup = uuidv4();
 
     const imageError = (event: any) => {
       // const image = event.target;

--- a/src/lib/PrimalNostr.ts
+++ b/src/lib/PrimalNostr.ts
@@ -1,4 +1,4 @@
-import { generatePrivateKey, getPublicKey, nip04, nip44, nip19, finalizeEvent, verifyEvent, generateNsec } from '../lib/nTools';
+import { generatePrivateKey, getPublicKey, nip04, nip44, nip19, finalizeEvent, verifyEvent } from '../lib/nTools';
 import { NostrExtension, NostrRelayEvent, NostrRelays, NostrRelaySignedEvent } from '../types/primal';
 import { readSecFromStorage, storeSec } from './localStore';
 import { base64 } from '@scure/base';
@@ -11,14 +11,9 @@ export const [currentPin, setCurrentPin] = createSignal('');
 
 export const [tempNsec, setTempNsec] = createSignal<string | undefined>();
 
-export const generateKeys = (forceNewKey?: boolean) => {
-  let sec = generatePrivateKey();
-  let nsec = readSecFromStorage();
-
-  if (forceNewKey) {
-    nsec = nip19.nsecEncode(sec);
-  }
-
+export const generateKeys = () => {
+  const sec = generatePrivateKey();
+  const nsec = nip19.nsecEncode(sec);
   const pubkey = getPublicKey(sec);
 
   return { sec, nsec, pubkey };
@@ -85,7 +80,11 @@ export const decryptWithPin = async (pin: string, cipher: string) => {
 
 export const PrimalNostr: (pk?: string) => NostrExtension = (pk?: string) => {
   const getSec = async () => {
-    let sec: string = pk || readSecFromStorage() || tempNsec() || generateNsec();
+    let sec: string | undefined = pk || readSecFromStorage() || tempNsec();
+
+    if (!sec) {
+      throw('no-nsec');
+    }
 
     if (sec.startsWith(pinEncodePrefix)) {
       sec = await decryptWithPin(currentPin(), sec);

--- a/src/pages/CreateAccount.tsx
+++ b/src/pages/CreateAccount.tsx
@@ -333,7 +333,7 @@ const CreateAccount: Component = () => {
   };
 
   onMount(() => {
-    const { nsec, pubkey } = generateKeys(true);
+    const { nsec, pubkey } = generateKeys();
 
     setSec(nsec);
     setTempNsec(nsec);

--- a/src/stores/accountStore.ts
+++ b/src/stores/accountStore.ts
@@ -5,6 +5,7 @@ import { getMembershipStatus } from "../lib/membership";
 import {
   areUrlsSame,
   handleSubscription,
+  uuidv4,
 } from "../utils";
 
 import {
@@ -32,7 +33,6 @@ import { NostrEventContent,
 } from "../types/primal";
 
 import {
-  generatePrivateKey,
   Relay,
   getPublicKey as nostrGetPubkey,
   nip19,
@@ -1626,7 +1626,7 @@ export const initAccountStore: AccountStore = {
       return;
     }
 
-    const random = generatePrivateKey();
+    const random = uuidv4();
     const subId = `fl_${random}_${APP_ID}`;
     let filterlists: Filterlist[] = [];
 
@@ -1652,7 +1652,7 @@ export const initAccountStore: AccountStore = {
       return;
     }
 
-    const random = generatePrivateKey();
+    const random = uuidv4();
     const subId = `bma_${random}_${APP_ID}`;
 
     let filterlists: Filterlist[] = [...accountStore.mutelists];
@@ -1697,7 +1697,7 @@ export const initAccountStore: AccountStore = {
       return;
     }
 
-    const random = generatePrivateKey();
+    const random = uuidv4();
     const subId = `bmr_${random}_${APP_ID}`;
     let filterlists: Filterlist[] = [...accountStore.mutelists];
 
@@ -1735,7 +1735,7 @@ export const initAccountStore: AccountStore = {
     if (!pubkey) {
       return;
     }
-    const random = generatePrivateKey();
+    const random = uuidv4();
     const subId = `bmu_${random}_${APP_ID}`;
 
     const unsub = subsTo(subId, {
@@ -1817,7 +1817,7 @@ export const initAccountStore: AccountStore = {
     if (!pubkey) {
       return;
     }
-    const random = generatePrivateKey();
+    const random = uuidv4();
     const subId = `baa_${random}_${APP_ID}`;
 
     const unsub = subsTo(subId, {
@@ -1859,7 +1859,7 @@ export const initAccountStore: AccountStore = {
     if (!pubkey) {
       return;
     }
-    const random = generatePrivateKey();
+    const random = uuidv4();
     const subId = `allow_list_remove_${random}_${APP_ID}`;
 
     const unsub = subsTo(subId, {


### PR DESCRIPTION
Fix a few issues with key handling:

- `PrimalNostr().getSec()` used to fall back to `generateNsec()` when no key was found in storage, so signing could silently publish events under a brand-new random identity. It now throws `'no-nsec'` instead. callers already handle throws from this path.
- `generateKeys(false)` returned an nsec from storage with a pubkey derived from a freshly generated key which could be a mismatched pair. The unused parameter is removed and it now always returns a matching sec/nsec/pubkey triple.
- Image/highlight ids and subscription ids were built with `generatePrivateKey()`, interpolating raw `Uint8Array` bytes into subscription id strings. These now use the existing `uuidv4()` helper. Real secret-key uses are untouched.