### PR TITLE
Pin crypto hardening

### DIFF
--- a/src/components/ArticleHighlight/ArticleHighlightActionMenu.tsx
+++ b/src/components/ArticleHighlight/ArticleHighlightActionMenu.tsx
@@ -3,7 +3,7 @@ import { Component, Match, Show, Switch } from 'solid-js';
 import { Kind } from '../../constants';
 import { hookForDev } from '../../lib/devTools';
 import { removeHighlight, sendHighlight } from '../../lib/highlights';
-import { generatePrivateKey } from '../../lib/nTools';
+import { uuidv4 } from '../../utils';
 import { NostrRelaySignedEvent, PrimalArticle, } from '../../types/primal';
 
 import styles from './ArticleHighlight.module.scss';
@@ -120,7 +120,7 @@ const ArticleHighlightActionMenu: Component<{
       const { content, context } = generateContentAndContext(props.selection);
 
       const highlight = {
-        id: `${generatePrivateKey()}`,
+        id: uuidv4(),
         kind: Kind.Highlight,
         context,
         content,
@@ -151,7 +151,7 @@ const ArticleHighlightActionMenu: Component<{
       const context = (props.highlight.tags.find((t: string[]) => t[0] === 'context') || [])[1];
 
       const highlight = {
-        id: `${generatePrivateKey()}`,
+        id: uuidv4(),
         kind: Kind.Highlight,
         context,
         content,

--- a/src/components/DirectMessages/DirectMessageParsedContent.tsx
+++ b/src/components/DirectMessages/DirectMessageParsedContent.tsx
@@ -9,12 +9,11 @@ import { useDMContext } from '../../contexts/DMContext';
 import { A } from '@solidjs/router';
 import { useAppContext } from '../../contexts/AppContext';
 import { decodeIdentifier, hexToNpub } from '../../lib/keys';
-import { isDev } from '../../utils';
+import { isDev, uuidv4 } from '../../utils';
 import { hashtagCharsRegex, Kind, linebreakRegex, lnUnifiedRegex, noteRegex, specialCharsRegex, urlExtractRegex } from '../../constants';
 import { createStore } from 'solid-js/store';
 import { NoteContent } from '../ParsedNote/ParsedNote';
 import { isInterpunction, isUrl, isImage, isMp4Video, isOggVideo, isWebmVideo, isYouTube, isSpotify, isTwitch, isMixCloud, isSoundCloud, isAppleMusic, isWavelake, getLinkPreview, isNoteMention, isUserMention, isAddrMention, isTagMention, isHashtag, isCustomEmoji, isUnitifedLnAddress, isLnbc, is3gppVideo } from '../../lib/notes';
-import { generatePrivateKey } from '../../lib/nTools';
 import { useMediaContext } from '../../contexts/MediaContext';
 import NoteImage from '../NoteImage/NoteImage';
 import { getMediaUrl as getMediaUrlDefault } from "../../lib/media";
@@ -392,7 +391,7 @@ const DirectMessageParsedContent: Component<{
   const renderImage = (item: NoteContent, index?: number) => {
 
     const groupCount = item.tokens.length;
-    const imageGroup = generatePrivateKey();
+    const imageGroup = uuidv4();
 
     // Remove bottom margin if media is the last thing in the note
     const lastClass = index === content.length-1 ?

--- a/src/components/LiveVideo/ChatMessage.tsx
+++ b/src/components/LiveVideo/ChatMessage.tsx
@@ -9,12 +9,11 @@ import { useDMContext } from '../../contexts/DMContext';
 import { A } from '@solidjs/router';
 import { useAppContext } from '../../contexts/AppContext';
 import { decodeIdentifier, hexToNpub } from '../../lib/keys';
-import { isDev, urlEncode } from '../../utils';
+import { isDev, urlEncode, uuidv4 } from '../../utils';
 import { hashtagCharsRegex, Kind, linebreakRegex, lnUnifiedRegex, noteRegex, specialCharsRegex, urlExtractRegex } from '../../constants';
 import { createStore } from 'solid-js/store';
 import { NoteContent } from '../ParsedNote/ParsedNote';
 import { isInterpunction, isUrl, isImage, isMp4Video, isOggVideo, isWebmVideo, isYouTube, isSpotify, isTwitch, isMixCloud, isSoundCloud, isAppleMusic, isWavelake, getLinkPreview, isNoteMention, isUserMention, isAddrMention, isTagMention, isHashtag, isCustomEmoji, isUnitifedLnAddress, isLnbc, is3gppVideo } from '../../lib/notes';
-import { generatePrivateKey } from '../../lib/nTools';
 import { useMediaContext } from '../../contexts/MediaContext';
 import NoteImage from '../NoteImage/NoteImage';
 import { getMediaUrl as getMediaUrlDefault } from "../../lib/media";
@@ -388,7 +387,7 @@ const ChatMessage: Component<{
   const renderImage = (item: NoteContent, index?: number) => {
 
     const groupCount = item.tokens.length;
-    const imageGroup = generatePrivateKey();
+    const imageGroup = uuidv4();
 
     // Remove bottom margin if media is the last thing in the note
     const lastClass = index === content.length-1 ?

--- a/src/components/LoginModal/GetStartedModal.tsx
+++ b/src/components/LoginModal/GetStartedModal.tsx
@@ -62,14 +62,14 @@ const GetStartedModal: Component<{
 
   const setupSigner = async () => {
     try {
-      generateAppKeys();
+      await generateAppKeys();
       const cUrl = generateClientConnectionUrl();
 
       if (cUrl.length === 0) return;
 
       setClientUrl(cUrl);
 
-      const sec = getAppSK();
+      const sec = await getAppSK();
 
       if (!sec) return;
 

--- a/src/components/LoginModal/LoginModal.tsx
+++ b/src/components/LoginModal/LoginModal.tsx
@@ -178,14 +178,14 @@ const LoginModal: Component<{
 
   const setupSigner = async () => {
     try {
-      generateAppKeys();
+      await generateAppKeys();
       const cUrl = generateClientConnectionUrl();
 
       if (cUrl.length === 0) return;
 
       setClientUrl(cUrl);
 
-      const sec = getAppSK();
+      const sec = await getAppSK();
 
       if (!sec) return;
 
@@ -209,7 +209,7 @@ const LoginModal: Component<{
 
   const onBunkerLogin = async () => {
     const bunkerUrl = bunkerInput?.value || '';
-    const sec = getAppSK();
+    const sec = await getAppSK();
 
     try {
       if (!sec) {

--- a/src/components/NostrImage/NostrImage.tsx
+++ b/src/components/NostrImage/NostrImage.tsx
@@ -1,6 +1,6 @@
 import { Component, createEffect, createSignal, JSX,  JSXElement,  onMount, Show } from "solid-js";
 import styles from "./NostrImage.module.scss";
-import { generatePrivateKey } from "../../lib/nTools";
+import { uuidv4 } from "../../utils";
 import { MediaVariant, NostrImageContent, NostrUserContent } from "../../types/primal";
 import { useAppContext } from "../../contexts/AppContext";
 
@@ -15,7 +15,7 @@ const NostrImage: Component<{
   event: NostrImageContent,
 }> = (props) => {
   const app = useAppContext();
-  const imgId = generatePrivateKey();
+  const imgId = uuidv4();
 
   let imgVirtual: HTMLImageElement | undefined;
   let imgWrapper: HTMLDivElement | undefined;

--- a/src/components/NoteImage/NoteImage.tsx
+++ b/src/components/NoteImage/NoteImage.tsx
@@ -1,6 +1,6 @@
 import { Component, createEffect, createSignal, JSX,  JSXElement,  onMount, Show } from "solid-js";
 import styles from "./NoteImage.module.scss";
-import { generatePrivateKey } from "../../lib/nTools";
+import { uuidv4 } from "../../utils";
 import { MediaVariant } from "../../types/primal";
 import { useAppContext } from "../../contexts/AppContext";
 import { cacheImages, isImageCached } from "../../lib/cache";
@@ -27,7 +27,7 @@ const NoteImage: Component<{
   isGallery?: boolean,
 }> = (props) => {
   const app = useAppContext();
-  const imgId = generatePrivateKey();
+  const imgId = uuidv4();
 
   let imgVirtual: HTMLImageElement | undefined;
   let imgActual: HTMLImageElement | undefined;

--- a/src/components/NoteImage/NoteImageSmall.tsx
+++ b/src/components/NoteImage/NoteImageSmall.tsx
@@ -1,6 +1,6 @@
 import { Component, createEffect, createSignal, JSX,  JSXElement,  onMount, Show } from "solid-js";
 import styles from "./NoteImage.module.scss";
-import { generatePrivateKey } from "../../lib/nTools";
+import { uuidv4 } from "../../utils";
 import { MediaVariant } from "../../types/primal";
 import { useAppContext } from "../../contexts/AppContext";
 
@@ -23,7 +23,7 @@ const NoteImageSmall: Component<{
   authorPk?: string,
 }> = (props) => {
   const app = useAppContext();
-  const imgId = generatePrivateKey();
+  const imgId = uuidv4();
 
   let imgVirtual: HTMLImageElement | undefined;
   let imgActual: HTMLImageElement | undefined;

--- a/src/components/ParsedNote/ParsedNote.tsx
+++ b/src/components/ParsedNote/ParsedNote.tsx
@@ -50,7 +50,7 @@ import {
 } from '../../types/primal';
 
 import styles from './ParsedNote.module.scss';
-import { nip19, generatePrivateKey } from '../../lib/nTools';
+import { nip19 } from '../../lib/nTools';
 import LinkPreview from '../LinkPreview/LinkPreview';
 import MentionedUserLink from '../Note/MentionedUserLink/MentionedUserLink';
 import { useMediaContext } from '../../contexts/MediaContext';
@@ -84,7 +84,7 @@ import { APP_ID } from '../../App';
 import { getEvents } from '../../lib/feed';
 import { subsTo } from '../../sockets';
 import ProfileNoteZap from '../ProfileNoteZap/ProfileNoteZap';
-import { parseBolt11 } from '../../utils';
+import { parseBolt11, uuidv4 } from '../../utils';
 import SimpleArticlePreview from '../ArticlePreview/SimpleArticlePreview';
 import NostrImage from '../NostrImage/NostrImage';
 import { StreamingData } from '../../lib/streaming';
@@ -656,7 +656,7 @@ const ParsedNote: Component<{
   const renderImage = (item: NoteContent, index?: number) => {
 
     const groupCount = item.tokens.length;
-    const imageGroup = generatePrivateKey();
+    const imageGroup = uuidv4();
 
     const imageError = (event: any) => {
       // const image = event.target;

--- a/src/components/ParsedNote/ParsedPoll.tsx
+++ b/src/components/ParsedNote/ParsedPoll.tsx
@@ -51,7 +51,7 @@ import {
 } from '../../types/primal';
 
 import styles from './ParsedNote.module.scss';
-import { nip19, generatePrivateKey } from '../../lib/nTools';
+import { nip19 } from '../../lib/nTools';
 import LinkPreview from '../LinkPreview/LinkPreview';
 import MentionedUserLink from '../Note/MentionedUserLink/MentionedUserLink';
 import { useMediaContext } from '../../contexts/MediaContext';
@@ -85,7 +85,7 @@ import { APP_ID } from '../../App';
 import { getEvents } from '../../lib/feed';
 import { subsTo } from '../../sockets';
 import ProfileNoteZap from '../ProfileNoteZap/ProfileNoteZap';
-import { parseBolt11 } from '../../utils';
+import { parseBolt11, uuidv4 } from '../../utils';
 import SimpleArticlePreview from '../ArticlePreview/SimpleArticlePreview';
 import NostrImage from '../NostrImage/NostrImage';
 import { StreamingData } from '../../lib/streaming';
@@ -650,7 +650,7 @@ const ParsedNote: Component<{
   const renderImage = (item: NoteContent, index?: number) => {
 
     const groupCount = item.tokens.length;
-    const imageGroup = generatePrivateKey();
+    const imageGroup = uuidv4();
 
     const imageError = (event: any) => {
       // const image = event.target;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -492,6 +492,8 @@ export const profileContactListPage = 50;
 
 export const pinEncodePrefix = 'prpec';
 export const pinEncodeIVSeparator = '?iv=';
+export const pinEncodePrefixV2 = 'prpec2';
+export const deviceEncodePrefix = 'prdev1';
 
 export const suggestedUsersToFollow = [
   "82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2", //jack

--- a/src/lib/PrimalNip46.ts
+++ b/src/lib/PrimalNip46.ts
@@ -5,6 +5,7 @@ import { uuidv4 } from '../utils';
 import { logWarning } from './logger';
 import primalLogo from '../assets/icons/logo_remote.png';
 import { timeoutPromise } from './nostrAPI';
+import { deviceDecrypt, deviceEncrypt, isDeviceEncrypted } from './deviceCrypto';
 
 export let appSigner: nip46.BunkerSigner | undefined;
 
@@ -12,24 +13,46 @@ export const setAppSigner = (bunker: nip46.BunkerSigner) => {
   appSigner = bunker;
 }
 
-export const generateAppKeys = (opts?: { reset?: boolean }) => {
+export const generateAppKeys = async (opts?: { reset?: boolean }) => {
   if (localStorage.getItem('appNsec') && !opts?.reset) return;
 
   let sk = generatePrivateKey();
   let pk = getPublicKey(sk);
 
-  localStorage.setItem('appNsec', bytesToHex(sk));
+  const enc = await deviceEncrypt(bytesToHex(sk));
+
+  if (!enc) return;
+
+  localStorage.setItem('appNsec', enc);
   localStorage.setItem('appPubkey', pk);
 }
 
 export const getAppPK = () => localStorage.getItem('appPubkey');
 
-export const getAppSK = () => {
-  const nsecHex = localStorage.getItem('appNsec');
+export const getAppSK = async () => {
+  const stored = localStorage.getItem('appNsec');
 
-  if (!nsecHex) return;
+  if (!stored) return;
 
   try {
+    let nsecHex = stored;
+
+    if (isDeviceEncrypted(stored)) {
+      const dec = await deviceDecrypt(stored);
+
+      if (!dec) return;
+
+      nsecHex = dec;
+    }
+    else {
+      // Legacy plaintext key; re-store it encrypted with the device key
+      const enc = await deviceEncrypt(stored);
+
+      if (enc) {
+        localStorage.setItem('appNsec', enc);
+      }
+    }
+
     const sk = hexToBytes(nsecHex);
 
     return sk;

--- a/src/lib/PrimalNostr.ts
+++ b/src/lib/PrimalNostr.ts
@@ -1,4 +1,4 @@
-import { generatePrivateKey, getPublicKey, nip04, nip44, nip19, finalizeEvent, verifyEvent, generateNsec } from '../lib/nTools';
+import { generatePrivateKey, getPublicKey, nip04, nip44, nip19, finalizeEvent, verifyEvent } from '../lib/nTools';
 import { NostrExtension, NostrRelayEvent, NostrRelays, NostrRelaySignedEvent } from '../types/primal';
 import { readSecFromStorage, storeSec } from './localStore';
 import { base64 } from '@scure/base';
@@ -11,14 +11,9 @@ export const [currentPin, setCurrentPin] = createSignal('');
 
 export const [tempNsec, setTempNsec] = createSignal<string | undefined>();
 
-export const generateKeys = (forceNewKey?: boolean) => {
-  let sec = generatePrivateKey();
-  let nsec = readSecFromStorage();
-
-  if (forceNewKey) {
-    nsec = nip19.nsecEncode(sec);
-  }
-
+export const generateKeys = () => {
+  const sec = generatePrivateKey();
+  const nsec = nip19.nsecEncode(sec);
   const pubkey = getPublicKey(sec);
 
   return { sec, nsec, pubkey };
@@ -85,7 +80,11 @@ export const decryptWithPin = async (pin: string, cipher: string) => {
 
 export const PrimalNostr: (pk?: string) => NostrExtension = (pk?: string) => {
   const getSec = async () => {
-    let sec: string = pk || readSecFromStorage() || tempNsec() || generateNsec();
+    let sec: string | undefined = pk || readSecFromStorage() || tempNsec();
+
+    if (!sec) {
+      throw('no-nsec');
+    }
 
     if (sec.startsWith(pinEncodePrefix)) {
       sec = await decryptWithPin(currentPin(), sec);

--- a/src/lib/PrimalNostr.ts
+++ b/src/lib/PrimalNostr.ts
@@ -2,7 +2,7 @@ import { generatePrivateKey, getPublicKey, nip04, nip44, nip19, finalizeEvent, v
 import { NostrExtension, NostrRelayEvent, NostrRelays, NostrRelaySignedEvent } from '../types/primal';
 import { readSecFromStorage, storeSec } from './localStore';
 import { base64 } from '@scure/base';
-import { pinEncodeIVSeparator, pinEncodePrefix } from '../constants';
+import { pinEncodeIVSeparator, pinEncodePrefix, pinEncodePrefixV2 } from '../constants';
 import { createSignal } from 'solid-js';
 import { logError } from './logger';
 
@@ -19,6 +19,44 @@ export const generateKeys = () => {
   return { sec, nsec, pubkey };
 };
 
+const PIN_KDF_ITERATIONS = 600_000;
+const PIN_SALT_LENGTH = 16;
+const PIN_IV_LENGTH = 12;
+
+// PBKDF2 is deliberately slow; cache the derived key so signing many events
+// during a session doesn't re-run the KDF on every getSec call.
+let cachedPinKey: { pin: string, saltB64: string, key: CryptoKey } | undefined;
+
+const derivePinKey = async (pin: string, salt: Uint8Array) => {
+  const saltB64 = base64.encode(salt);
+
+  if (cachedPinKey && cachedPinKey.pin === pin && cachedPinKey.saltB64 === saltB64) {
+    return cachedPinKey.key;
+  }
+
+  const utf8Encoder = new TextEncoder();
+
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    utf8Encoder.encode(pin),
+    'PBKDF2',
+    false,
+    ['deriveKey'],
+  );
+
+  const key = await crypto.subtle.deriveKey(
+    { name: 'PBKDF2', hash: 'SHA-256', salt, iterations: PIN_KDF_ITERATIONS },
+    keyMaterial,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+
+  cachedPinKey = { pin, saltB64, key };
+
+  return key;
+};
+
 export const encryptWithPin = async (pin: string, text: string) => {
   try {
     const crypto = window.crypto;
@@ -29,49 +67,93 @@ export const encryptWithPin = async (pin: string, text: string) => {
 
     const utf8Encoder = new TextEncoder();
 
-    const key = await crypto.subtle.digest('SHA-256', utf8Encoder.encode(pin));
+    const salt = crypto.getRandomValues(new Uint8Array(PIN_SALT_LENGTH));
+    const iv = crypto.getRandomValues(new Uint8Array(PIN_IV_LENGTH));
 
-    let iv = Uint8Array.from(crypto.getRandomValues(new Uint8Array(16)));
-    let plaintext = utf8Encoder.encode(text)
-    let cryptoKey = await crypto.subtle.importKey('raw', key, { name: 'AES-CBC' }, false, ['encrypt'])
-    let ciphertext = await crypto.subtle.encrypt({ name: 'AES-CBC', iv }, cryptoKey, plaintext)
-    let ctb64 = base64.encode(new Uint8Array(ciphertext))
-    let ivb64 = base64.encode(new Uint8Array(iv.buffer))
+    const key = await derivePinKey(pin, salt);
 
-    return `${pinEncodePrefix}${ctb64}${pinEncodeIVSeparator}${ivb64}`
+    const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, utf8Encoder.encode(text));
+
+    const payload = new Uint8Array(salt.length + iv.length + ciphertext.byteLength);
+    payload.set(salt, 0);
+    payload.set(iv, salt.length);
+    payload.set(new Uint8Array(ciphertext), salt.length + iv.length);
+
+    return `${pinEncodePrefixV2}${base64.encode(payload)}`;
   } catch(e) {
     logError('Failed to encrypt with PIN: ', e);
     return '';
   }
 };
 
+const decryptWithPinLegacy = async (pin: string, cipher: string) => {
+  const utf8Encoder = new TextEncoder();
+  const utf8Decoder = new TextDecoder('utf-8');
+
+  const data = cipher.slice(pinEncodePrefix.length);
+  const key = await crypto.subtle.digest('SHA-256', utf8Encoder.encode(pin));
+
+  let [ctb64, ivb64] = data.split(pinEncodeIVSeparator)
+
+  let cryptoKey = await crypto.subtle.importKey('raw', key, { name: 'AES-CBC' }, false, ['decrypt'])
+  let ciphertext = base64.decode(ctb64)
+  let iv = base64.decode(ivb64)
+
+  let plaintext = await crypto.subtle.decrypt({ name: 'AES-CBC', iv }, cryptoKey, ciphertext)
+
+  return utf8Decoder.decode(plaintext);
+};
+
+// Once a legacy blob decrypts to a valid nsec, replace the stored copy with
+// the v2 format. Only touches storage when the cipher is the stored sec, so
+// a wrong-PIN decrypt that slips past CBC padding can't clobber the key.
+const upgradeLegacyPinCipher = async (pin: string, plain: string, legacyCipher: string) => {
+  try {
+    if (readSecFromStorage() !== legacyCipher) return;
+
+    const decoded = nip19.decode(plain);
+    if (decoded.type !== 'nsec' || !decoded.data) return;
+
+    const enc = await encryptWithPin(pin, plain);
+    if (enc.startsWith(pinEncodePrefixV2)) {
+      storeSec(enc);
+    }
+  } catch(e) {
+    logError('Failed to upgrade legacy PIN cipher: ', e);
+  }
+};
+
 export const decryptWithPin = async (pin: string, cipher: string) => {
   try {
-    if (!cipher.startsWith(pinEncodePrefix)) {
-      throw('bad-cipher');
-    }
-
     const crypto = window.crypto;
 
     if (!crypto) {
       throw('not-secure-env');
     }
-    const utf8Encoder = new TextEncoder();
-    const utf8Decoder = new TextDecoder('utf-8');
 
-    const data = cipher.slice(pinEncodePrefix.length);
-    const key = await crypto.subtle.digest('SHA-256', utf8Encoder.encode(pin));
+    if (cipher.startsWith(pinEncodePrefixV2)) {
+      const payload = base64.decode(cipher.slice(pinEncodePrefixV2.length));
 
-    let [ctb64, ivb64] = data.split(pinEncodeIVSeparator)
+      const salt = payload.slice(0, PIN_SALT_LENGTH);
+      const iv = payload.slice(PIN_SALT_LENGTH, PIN_SALT_LENGTH + PIN_IV_LENGTH);
+      const ciphertext = payload.slice(PIN_SALT_LENGTH + PIN_IV_LENGTH);
 
-    let cryptoKey = await crypto.subtle.importKey('raw', key, { name: 'AES-CBC' }, false, ['decrypt'])
-    let ciphertext = base64.decode(ctb64)
-    let iv = base64.decode(ivb64)
+      const key = await derivePinKey(pin, salt);
 
-    let plaintext = await crypto.subtle.decrypt({ name: 'AES-CBC', iv }, cryptoKey, ciphertext)
+      const plaintext = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
 
-    let text = utf8Decoder.decode(plaintext)
-    return text
+      return new TextDecoder('utf-8').decode(plaintext);
+    }
+
+    if (!cipher.startsWith(pinEncodePrefix)) {
+      throw('bad-cipher');
+    }
+
+    const text = await decryptWithPinLegacy(pin, cipher);
+
+    await upgradeLegacyPinCipher(pin, text, cipher);
+
+    return text;
   } catch(e) {
     logError('Failed to decrypt with PIN: ', e);
     return '';

--- a/src/lib/deviceCrypto.ts
+++ b/src/lib/deviceCrypto.ts
@@ -1,0 +1,111 @@
+import { base64 } from '@scure/base';
+import { deviceEncodePrefix } from '../constants';
+import { logError } from './logger';
+
+// A non-extractable AES-GCM key kept in IndexedDB, used to encrypt values
+// that have to live in localStorage but shouldn't be readable from a raw
+// storage dump (e.g. the NIP-46 client transport key). The key material
+// never leaves WebCrypto; losing the IndexedDB entry just means re-pairing.
+
+const DB_NAME = 'primal-device-keys';
+const STORE_NAME = 'keys';
+const DEVICE_KEY_ID = 'device-key-v1';
+const IV_LENGTH = 12;
+
+let devicePkPromise: Promise<CryptoKey> | undefined;
+
+const openDb = () => new Promise<IDBDatabase>((resolve, reject) => {
+  const req = indexedDB.open(DB_NAME, 1);
+
+  req.onupgradeneeded = () => {
+    req.result.createObjectStore(STORE_NAME);
+  };
+  req.onsuccess = () => resolve(req.result);
+  req.onerror = () => reject(req.error);
+});
+
+const idbGet = (db: IDBDatabase, id: string) => new Promise<CryptoKey | undefined>((resolve, reject) => {
+  const req = db.transaction(STORE_NAME, 'readonly').objectStore(STORE_NAME).get(id);
+
+  req.onsuccess = () => resolve(req.result);
+  req.onerror = () => reject(req.error);
+});
+
+const idbPut = (db: IDBDatabase, id: string, key: CryptoKey) => new Promise<void>((resolve, reject) => {
+  const req = db.transaction(STORE_NAME, 'readwrite').objectStore(STORE_NAME).put(key, id);
+
+  req.onsuccess = () => resolve();
+  req.onerror = () => reject(req.error);
+});
+
+const getDeviceKey = () => {
+  if (!devicePkPromise) {
+    devicePkPromise = (async () => {
+      const db = await openDb();
+
+      try {
+        let key = await idbGet(db, DEVICE_KEY_ID);
+
+        if (!key) {
+          key = await crypto.subtle.generateKey(
+            { name: 'AES-GCM', length: 256 },
+            false,
+            ['encrypt', 'decrypt'],
+          );
+          await idbPut(db, DEVICE_KEY_ID, key);
+        }
+
+        return key;
+      } finally {
+        db.close();
+      }
+    })();
+
+    devicePkPromise.catch(() => { devicePkPromise = undefined; });
+  }
+
+  return devicePkPromise;
+};
+
+export const isDeviceEncrypted = (value: string) => value.startsWith(deviceEncodePrefix);
+
+export const deviceEncrypt = async (text: string) => {
+  try {
+    const key = await getDeviceKey();
+    const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH));
+
+    const ciphertext = await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv },
+      key,
+      new TextEncoder().encode(text),
+    );
+
+    const payload = new Uint8Array(iv.length + ciphertext.byteLength);
+    payload.set(iv, 0);
+    payload.set(new Uint8Array(ciphertext), iv.length);
+
+    return `${deviceEncodePrefix}${base64.encode(payload)}`;
+  } catch(e) {
+    logError('Failed to encrypt with device key: ', e);
+    return undefined;
+  }
+};
+
+export const deviceDecrypt = async (cipher: string) => {
+  try {
+    if (!isDeviceEncrypted(cipher)) return undefined;
+
+    const key = await getDeviceKey();
+    const payload = base64.decode(cipher.slice(deviceEncodePrefix.length));
+
+    const iv = payload.slice(0, IV_LENGTH);
+    const ciphertext = payload.slice(IV_LENGTH);
+
+    const plaintext = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
+
+    return new TextDecoder('utf-8').decode(plaintext);
+  } catch(e) {
+    logError('Failed to decrypt with device key: ', e);
+    return undefined;
+  }
+};

--- a/src/pages/CreateAccount.tsx
+++ b/src/pages/CreateAccount.tsx
@@ -333,7 +333,7 @@ const CreateAccount: Component = () => {
   };
 
   onMount(() => {
-    const { nsec, pubkey } = generateKeys(true);
+    const { nsec, pubkey } = generateKeys();
 
     setSec(nsec);
     setTempNsec(nsec);

--- a/src/stores/accountStore.ts
+++ b/src/stores/accountStore.ts
@@ -2343,7 +2343,7 @@ export const initAccountStore: AccountStore = {
   export const loginUsingNip46 = async (pk?: string) => {
     setLoginType('nip46');
 
-    const sec = getAppSK();
+    const sec = await getAppSK();
     const bunkerUrl = localStorage.getItem('bunkerUrl');
 
     if (!sec || !bunkerUrl) {

--- a/src/stores/accountStore.ts
+++ b/src/stores/accountStore.ts
@@ -5,6 +5,7 @@ import { getMembershipStatus } from "../lib/membership";
 import {
   areUrlsSame,
   handleSubscription,
+  uuidv4,
 } from "../utils";
 
 import {
@@ -32,7 +33,6 @@ import { NostrEventContent,
 } from "../types/primal";
 
 import {
-  generatePrivateKey,
   Relay,
   getPublicKey as nostrGetPubkey,
   nip19,
@@ -1626,7 +1626,7 @@ export const initAccountStore: AccountStore = {
       return;
     }
 
-    const random = generatePrivateKey();
+    const random = uuidv4();
     const subId = `fl_${random}_${APP_ID}`;
     let filterlists: Filterlist[] = [];
 
@@ -1652,7 +1652,7 @@ export const initAccountStore: AccountStore = {
       return;
     }
 
-    const random = generatePrivateKey();
+    const random = uuidv4();
     const subId = `bma_${random}_${APP_ID}`;
 
     let filterlists: Filterlist[] = [...accountStore.mutelists];
@@ -1697,7 +1697,7 @@ export const initAccountStore: AccountStore = {
       return;
     }
 
-    const random = generatePrivateKey();
+    const random = uuidv4();
     const subId = `bmr_${random}_${APP_ID}`;
     let filterlists: Filterlist[] = [...accountStore.mutelists];
 
@@ -1735,7 +1735,7 @@ export const initAccountStore: AccountStore = {
     if (!pubkey) {
       return;
     }
-    const random = generatePrivateKey();
+    const random = uuidv4();
     const subId = `bmu_${random}_${APP_ID}`;
 
     const unsub = subsTo(subId, {
@@ -1817,7 +1817,7 @@ export const initAccountStore: AccountStore = {
     if (!pubkey) {
       return;
     }
-    const random = generatePrivateKey();
+    const random = uuidv4();
     const subId = `baa_${random}_${APP_ID}`;
 
     const unsub = subsTo(subId, {
@@ -1859,7 +1859,7 @@ export const initAccountStore: AccountStore = {
     if (!pubkey) {
       return;
     }
-    const random = generatePrivateKey();
+    const random = uuidv4();
     const subId = `allow_list_remove_${random}_${APP_ID}`;
 
     const unsub = subsTo(subId, {


### PR DESCRIPTION
Hardens encryption-at-rest for keys in localStorage. Follow-up to the key handling fixes in 69980459. No UX changes, existing PINs keep working and migration is automatic.

**PIN encryption: PBKDF2 + AES-GCM (new `prpec2` format)**

The current `encryptWithPin`/`decryptWithPin` derive the AES key from a single unsalted SHA-256 of the PIN and encrypt with unauthenticated AES-CBC. That makes stored blobs cheap to brute-force offline (one hash per guess, precomputable) and means a wrong PIN can occasionally "decrypt" to garbage instead of failing.

This PR:
- Derives the key with PBKDF2-SHA256, 600,000 iterations, random 16-byte salt, and encrypts with AES-256-GCM (authenticated). New blobs use a `prpec2` prefix; format is `prpec2` + base64(salt ‖ iv ‖ ciphertext).
- Keeps the legacy `prpec` decrypt path. Legacy blobs are lazily re-encrypted to the new format after a successful unlock. The upgrade only runs when the cipher matches what's currently in storage and the plaintext validates as an nsec, so a bad decrypt can never overwrite the stored key.
- Caches the derived key in memory (keyed by PIN + salt), so signing many events doesn't re-run the slow KDF on every operation.

Existing `startsWith(pinEncodePrefix)` checks elsewhere match both prefixes ("prpec2…" starts with "prpec"), so login/unlock flows need no changes.

**NIP-46 transport key: encrypted with a device key**

The NIP-46 client transport key (`appNsec`) was stored as plaintext hex in localStorage. Since bunker users never set a PIN, it's now encrypted with a **non-extractable AES-GCM key stored in IndexedDB** (new `src/lib/deviceCrypto.ts`, `prdev1` prefix). A raw localStorage dump no longer yields the key; the key material itself never leaves WebCrypto.

- Legacy plaintext values are migrated on first read.
- If the IndexedDB key is ever lost, `getAppSK` returns undefined and the bunker simply re-pairs. the transport key is not identity-bearing.
- `generateAppKeys`/`getAppSK` became async; all call sites were already in async functions and are updated.