### PR TITLE
feat: translate posts to user's preferred language (#133)

### DIFF
--- a/src/components/Note/Note.module.scss
+++ b/src/components/Note/Note.module.scss
@@ -1370,3 +1370,60 @@
 .missingThumb {
   border:1px solid red;
 }
+
+.noteTranslate {
+  margin-top: 6px;
+
+  .noteTranslateButton {
+    background: none;
+    border: none;
+    padding: 0;
+    color: var(--text-secondary);
+    font-size: 14px;
+    line-height: 18px;
+    cursor: pointer;
+
+    &:hover {
+      color: var(--text-primary);
+      text-decoration: underline;
+    }
+
+    &:disabled {
+      cursor: default;
+      opacity: 0.6;
+    }
+  }
+
+  .noteTranslateError {
+    color: var(--text-tertiary);
+    font-size: 14px;
+    line-height: 18px;
+  }
+
+  .noteTranslated {
+    padding: 8px 12px;
+    margin-top: 4px;
+    border-left: 2px solid var(--devider);
+    border-radius: 4px;
+    background-color: var(--background-card);
+
+    .noteTranslatedText {
+      color: var(--text-primary);
+      font-size: 15px;
+      line-height: 22px;
+      word-break: break-word;
+      white-space: pre-wrap;
+    }
+
+    .noteTranslatedMeta {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 8px;
+      margin-top: 8px;
+      color: var(--text-tertiary);
+      font-size: 13px;
+      line-height: 16px;
+    }
+  }
+}

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -3,6 +3,7 @@ import { batch, Component, createEffect, Match, on, onMount, Show, Switch } from
 import { PrimalNote, PrimalUser, TopZap, ZapOption } from '../../types/primal';
 import ParsedNote from '../ParsedNote/ParsedNote';
 import NoteFooter from './NoteFooter/NoteFooter';
+import NoteTranslate from './NoteTranslate';
 
 import styles from './Note.module.scss';
 import { useThreadContext } from '../../contexts/ThreadContext';
@@ -414,6 +415,8 @@ const Note: Component<NoteProps> = (props) => {
               />
             </div>
 
+            <NoteTranslate note={props.note} />
+
             <div class={styles.topZaps}>
               <NoteTopZaps
                 topZaps={reactionsState.topZapsFeed}
@@ -557,6 +560,8 @@ const Note: Component<NoteProps> = (props) => {
             />
           </div>
 
+          <NoteTranslate note={props.note} />
+
           <NoteTopZapsCompact
             note={props.note}
             action={() => openReactionModal('zaps')}
@@ -643,6 +648,8 @@ const Note: Component<NoteProps> = (props) => {
                   footerSize="short"
                 />
               </div>
+
+              <NoteTranslate note={props.note} />
 
               <NoteTopZapsCompact
                 note={props.note}

--- a/src/components/Note/NoteTranslate.tsx
+++ b/src/components/Note/NoteTranslate.tsx
@@ -1,0 +1,99 @@
+import { Component, createSignal, Show } from 'solid-js';
+import { PrimalNote } from '../../types/primal';
+import {
+  cacheTranslation,
+  decodeNoteContent,
+  getCachedTranslation,
+  getTranslateLang,
+  translateNoteContent,
+  TranslationResult,
+} from '../../lib/noteTranslation';
+
+import styles from './Note.module.scss';
+
+const NoteTranslate: Component<{ note: PrimalNote }> = (props) => {
+  const [translated, setTranslated] = createSignal<TranslationResult | undefined>(undefined);
+  const [translating, setTranslating] = createSignal(false);
+  const [failed, setFailed] = createSignal(false);
+
+  const translate = async (e: MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (translating()) return;
+
+    const target = getTranslateLang();
+    const cached = getCachedTranslation(props.note.id, target);
+
+    if (cached) {
+      setTranslated(cached);
+      return;
+    }
+
+    setTranslating(true);
+    setFailed(false);
+
+    const result = await translateNoteContent(props.note.content, target);
+
+    setTranslating(false);
+
+    if (result) {
+      cacheTranslation(props.note.id, target, result);
+      setTranslated(result);
+    } else {
+      setFailed(true);
+    }
+  };
+
+  const showOriginal = (e: MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    setTranslated(undefined);
+    setFailed(false);
+  };
+
+  return (
+    <Show when={props.note.content.trim().length > 0}>
+      <div class={styles.noteTranslate} onClick={(e) => e.stopPropagation()}>
+        <Show
+          when={translated() === undefined}
+          fallback={
+            <div class={styles.noteTranslated}>
+              <div class={styles.noteTranslatedText}>{translated()?.text}</div>
+              <div class={styles.noteTranslatedMeta}>
+                <span>
+                  {translated()?.engine === 'google'
+                    ? 'Translated by Google Translate'
+                    : 'Translated by LibreTranslate'}
+                </span>
+                <button class={styles.noteTranslateButton} onClick={showOriginal}>
+                  Show original
+                </button>
+              </div>
+            </div>
+          }
+        >
+          <Show
+            when={!failed()}
+            fallback={
+              <div class={styles.noteTranslateError}>
+                Translation is unavailable right now. Please try again later.
+              </div>
+            }
+          >
+            <button
+              class={styles.noteTranslateButton}
+              onClick={translate}
+              disabled={translating()}
+            >
+              {translating() ? 'Translating…' : 'Translate'}
+            </button>
+          </Show>
+        </Show>
+      </div>
+    </Show>
+  );
+};
+
+export default NoteTranslate;

--- a/src/lib/noteTranslation.ts
+++ b/src/lib/noteTranslation.ts
@@ -1,0 +1,180 @@
+// Translation of note content into the user's preferred language.
+//
+// Uses free, keyless public translation endpoints, so no API key is required:
+// the public LibreTranslate instances are tried first, and, if none of them is
+// reachable, we fall back to the free Google Translate endpoint
+// (translate.googleapis.com), which is CORS-enabled and requires no key.
+
+const STORAGE_KEY = 'primal_translate_lang';
+
+export type TranslationEngine = 'libretranslate' | 'google';
+
+export type TranslationResult = {
+  text: string,
+  engine: TranslationEngine,
+};
+
+export type TranslationLanguage = {
+  code: string,
+  name: string,
+};
+
+// A curated list of the most common target languages.
+// Codes are ISO 639-1 (LibreTranslate style); Google-specific variants
+// (zh-Hans, nb, pt-BR) are mapped to their Google equivalents when used.
+export const TRANSLATION_LANGUAGES: TranslationLanguage[] = [
+  { code: 'en', name: 'English' },
+  { code: 'es', name: 'Spanish' },
+  { code: 'fr', name: 'French' },
+  { code: 'de', name: 'German' },
+  { code: 'it', name: 'Italian' },
+  { code: 'pt', name: 'Portuguese' },
+  { code: 'nl', name: 'Dutch' },
+  { code: 'ru', name: 'Russian' },
+  { code: 'uk', name: 'Ukrainian' },
+  { code: 'pl', name: 'Polish' },
+  { code: 'cs', name: 'Czech' },
+  { code: 'sk', name: 'Slovak' },
+  { code: 'sv', name: 'Swedish' },
+  { code: 'nb', name: 'Norwegian' },
+  { code: 'da', name: 'Danish' },
+  { code: 'fi', name: 'Finnish' },
+  { code: 'el', name: 'Greek' },
+  { code: 'tr', name: 'Turkish' },
+  { code: 'ar', name: 'Arabic' },
+  { code: 'he', name: 'Hebrew' },
+  { code: 'hi', name: 'Hindi' },
+  { code: 'bn', name: 'Bengali' },
+  { code: 'th', name: 'Thai' },
+  { code: 'vi', name: 'Vietnamese' },
+  { code: 'id', name: 'Indonesian' },
+  { code: 'ja', name: 'Japanese' },
+  { code: 'ko', name: 'Korean' },
+  { code: 'zh-Hans', name: 'Chinese (Simplified)' },
+];
+
+const LIBRETRANSLATE_INSTANCES = [
+  'https://libretranslate.com/translate',
+  'https://translate.terraprint.co/translate',
+  'https://libretranslate.pussthecat.org/translate',
+  'https://lt.vern.cc/translate',
+];
+
+const GOOGLE_TRANSLATE_URL = 'https://translate.googleapis.com/translate_a/single';
+
+// In-memory cache of translated notes: noteId -> last translation result
+// (kept together with the target language it was translated into).
+const translationCache: Record<string, TranslationResult & { target: string }> = {};
+
+const stripRegion = (lang: string) => lang.split('-')[0].toLowerCase();
+
+export const defaultTranslateLang = () => {
+  const browserLang = typeof navigator !== 'undefined' ? stripRegion(navigator.language) : '';
+
+  const normalized = browserLang === 'zh' ? 'zh-Hans' : browserLang;
+
+  return TRANSLATION_LANGUAGES.some((l) => l.code === normalized) ? normalized : 'en';
+};
+
+export const getTranslateLang = () => {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+
+    if (stored && TRANSLATION_LANGUAGES.some((l) => l.code === stored)) {
+      return stored;
+    }
+  } catch (e) {
+    // localStorage might be unavailable; fall back to the default.
+  }
+
+  return defaultTranslateLang();
+};
+
+export const setTranslateLang = (lang: string) => {
+  try {
+    localStorage.setItem(STORAGE_KEY, lang);
+  } catch (e) {
+    // Ignore: the preference is not critical.
+  }
+};
+
+const toGoogleTarget = (target: string) => {
+  switch (target) {
+    case 'zh-Hans': return 'zh-CN';
+    case 'nb': return 'no';
+    case 'pt-BR': return 'pt';
+    default: return target;
+  }
+};
+
+// Note content is stored with `<` and `>` escaped (see sanitize in lib/notes),
+// so we decode them back before handing the text to the translation service.
+export const decodeNoteContent = (content: string) =>
+  content.replaceAll('&lt;', '<').replaceAll('&gt;', '>');
+
+const translateViaLibreTranslate = async (q: string, target: string) => {
+  for (const url of LIBRETRANSLATE_INSTANCES) {
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ q, source: 'auto', target, format: 'text' }),
+      });
+
+      if (!res.ok) {
+        continue;
+      }
+
+      const data = await res.json();
+
+      if (data && typeof data.translatedText === 'string' && data.translatedText.length > 0) {
+        return data.translatedText as string;
+      }
+    } catch (e) {
+      // Instance is unreachable; try the next one.
+    }
+  }
+
+  return undefined;
+};
+
+const translateViaGoogle = async (q: string, target: string) => {
+  const url = `${GOOGLE_TRANSLATE_URL}?client=gtx&sl=auto&tl=${toGoogleTarget(target)}&dt=t&q=${encodeURIComponent(q)}`;
+
+  const res = await fetch(url);
+
+  if (!res.ok) {
+    return undefined;
+  }
+
+  const data = await res.json();
+  const text = data?.[0]?.[0]?.[0];
+
+  return typeof text === 'string' && text.length > 0 ? text : undefined;
+};
+
+export const translateNoteContent = async (text: string, target: string): Promise<TranslationResult | undefined> => {
+  const ltText = await translateViaLibreTranslate(text, target);
+
+  if (ltText) {
+    return { text: ltText, engine: 'libretranslate' };
+  }
+
+  const googleText = await translateViaGoogle(text, target);
+
+  if (googleText) {
+    return { text: googleText, engine: 'google' };
+  }
+
+  return undefined;
+};
+
+export const getCachedTranslation = (noteId: string, target: string) => {
+  const cached = translationCache[noteId];
+
+  return cached && cached.target === target ? cached : undefined;
+};
+
+export const cacheTranslation = (noteId: string, target: string, result: TranslationResult) => {
+  translationCache[noteId] = { ...result, target };
+};

--- a/src/pages/Settings/Appearance.tsx
+++ b/src/pages/Settings/Appearance.tsx
@@ -1,4 +1,4 @@
-import { Component } from 'solid-js';
+import { Component, For } from 'solid-js';
 import styles from './Settings.module.scss';
 
 import ThemeChooser from '../../components/ThemeChooser/ThemeChooser';
@@ -9,6 +9,11 @@ import { A } from '@solidjs/router';
 import PageTitle from '../../components/PageTitle/PageTitle';
 import CheckBox from '../../components/Checkbox/CheckBox';
 import { useSettingsContext } from '../../contexts/SettingsContext';
+import {
+  getTranslateLang,
+  setTranslateLang,
+  TRANSLATION_LANGUAGES,
+} from '../../lib/noteTranslation';
 
 const Appearance: Component = () => {
 
@@ -30,6 +35,26 @@ const Appearance: Component = () => {
         </div>
 
         <ThemeChooser />
+
+        <div class={styles.settingsCaption}>
+          Translation language
+        </div>
+
+        <div class={styles.settingsSelectRow}>
+          <select
+            class={styles.settingsSelect}
+            value={getTranslateLang()}
+            onChange={(e) => setTranslateLang((e.target as HTMLSelectElement).value)}
+          >
+            <For each={TRANSLATION_LANGUAGES}>
+              {(lang) => <option value={lang.code}>{lang.name}</option>}
+            </For>
+          </select>
+
+          <div class={styles.settingsSelectHint}>
+            Notes will be translated into this language with the "Translate" button.
+          </div>
+        </div>
 
         <div>
           <CheckBox

--- a/src/pages/Settings/Settings.module.scss
+++ b/src/pages/Settings/Settings.module.scss
@@ -63,6 +63,33 @@
   align-items: center;
 }
 
+.settingsSelectRow {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: -10px;
+  margin-bottom: 20px;
+}
+
+.settingsSelect {
+  width: fit-content;
+  min-width: 180px;
+  padding: 8px 12px;
+  color: var(--text-primary);
+  background-color: var(--background-card);
+  border: 1px solid var(--devider);
+  border-radius: 6px;
+  font-size: 14px;
+  line-height: 18px;
+  cursor: pointer;
+}
+
+.settingsSelectHint {
+  color: var(--text-tertiary);
+  font-size: 13px;
+  line-height: 16px;
+}
+
 .settingsCaptionDarker {
   font-size: 18px;
   font-weight: 400;


### PR DESCRIPTION
Closes #133 — Translate posts to user's preferred language

Adds a **Translate** button on every note (thread, feed, single-note, mobile). Uses free keyless translation (LibreTranslate public instances → Google Translate fallback, no API key required), a language preference in Settings → Appearance (28 languages, defaults to browser language), and in-memory per-note caching so toggling is instant. Translated posts show attribution + "Show original".
