### PR TITLE
Add on-demand translation for posts

### DIFF
--- a/src/components/Note/NoteContextMenu.tsx
+++ b/src/components/Note/NoteContextMenu.tsx
@@ -1,5 +1,5 @@
 import { Component, createEffect, createSignal } from 'solid-js';
-import { MenuItem, NostrRelaySignedEvent, PrimalArticle } from '../../types/primal';
+import { MenuItem, NostrRelaySignedEvent, PrimalArticle, PrimalNote } from '../../types/primal';
 
 import styles from './Note.module.scss';
 import { useIntl } from '@cookbook/solid-intl';
@@ -17,6 +17,7 @@ import { useNavigate } from '@solidjs/router';
 import { Kind } from '../../constants';
 import { urlEncode } from '../../utils';
 import { accountStore, addToMuteList, hasPublicKey, removeFromMuteList, setShowPin, showGetStarted } from '../../stores/accountStore';
+import { useTranslatorContext } from '../../contexts/TranslatorContext';
 
 const NoteContextMenu: Component<{
   data: NoteContextMenuInfo,
@@ -27,6 +28,7 @@ const NoteContextMenu: Component<{
   const toaster = useToastContext();
   const intl = useIntl();
   const app = useAppContext();
+  const translator = useTranslatorContext();
   const navigate = useNavigate();
 
   const [confirmMuteUser, setConfirmMuteUser] = createSignal(false);
@@ -150,6 +152,14 @@ const NoteContextMenu: Component<{
     toaster?.sendSuccess(intl.formatMessage(tToast.notePrimalTextCoppied));
   };
 
+  const translateNote = () => {
+    const current = note();
+    if (!current || [Kind.UserPoll, Kind.ZapPoll].includes(current.msg.kind)) return;
+
+    translator?.actions.translateNote(current as PrimalNote);
+    props.onClose();
+  };
+
   const copyNoteId = () => {
     if (!props.data) return;
     navigator.clipboard.writeText(`nostr:${note().noteId}`);
@@ -249,6 +259,7 @@ const NoteContextMenu: Component<{
   }
 
   const noteContextForEveryone: () => MenuItem[] = () => {
+    const isPoll = [Kind.UserPoll, Kind.ZapPoll].includes(props.data?.note?.msg.kind);
 
     return [
       {
@@ -277,6 +288,15 @@ const NoteContextMenu: Component<{
         action: copyNoteText,
         icon: 'copy_note_text',
       },
+      ...(isPoll ? [] : [{
+        label: intl.formatMessage({
+          id: 'actions.noteContext.translate',
+          defaultMessage: 'Translate',
+          description: 'Translate a note into the selected language',
+        }),
+        action: translateNote,
+        icon: 'copy_note_text',
+      }]),
       {
         label: [Kind.UserPoll, Kind.ZapPoll].includes(props.data?.note?.msg.kind) ? intl.formatMessage(tActions.pollContext.copyId) : intl.formatMessage(tActions.noteContext.copyId),
         action: copyNoteId,

--- a/src/components/ParsedNote/ParsedNote.module.scss
+++ b/src/components/ParsedNote/ParsedNote.module.scss
@@ -205,3 +205,37 @@
 .audio {
   margin-top: 12px;
 }
+
+.translation {
+  margin-bottom: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--subtile-devider);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--border-radius-small);
+  color: var(--text-primary);
+  background-color: var(--background-header-input);
+  white-space: pre-wrap;
+}
+
+.translationLabel {
+  margin-bottom: 4px;
+  color: var(--text-tertiary);
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.translationStatus,
+.translationRetry {
+  margin-bottom: 10px;
+  color: var(--text-tertiary);
+  font-size: 13px;
+}
+
+.translationRetry {
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--accent);
+  cursor: pointer;
+}

--- a/src/components/ParsedNote/ParsedNote.tsx
+++ b/src/components/ParsedNote/ParsedNote.tsx
@@ -54,6 +54,7 @@ import { nip19, generatePrivateKey } from '../../lib/nTools';
 import LinkPreview from '../LinkPreview/LinkPreview';
 import MentionedUserLink from '../Note/MentionedUserLink/MentionedUserLink';
 import { useMediaContext } from '../../contexts/MediaContext';
+import { useTranslatorContext } from '../../contexts/TranslatorContext';
 import { hookForDev } from '../../lib/devTools';
 import { getMediaVariantFromTags, getMediaUrl as getMediaUrlDefault } from "../../lib/media";
 import NoteImage from '../NoteImage/NoteImage';
@@ -200,6 +201,7 @@ const ParsedNote: Component<{
   const intl = useIntl();
   const media = useMediaContext();
   const app = useAppContext();
+  const translator = useTranslatorContext();
 
   const dev = localStorage.getItem('devMode') === 'true';
 
@@ -2163,6 +2165,25 @@ const ParsedNote: Component<{
 
   return (
     <div ref={thisNote} id={id()} class={`${styles.parsedNote} ${props.veryShort ? styles.shortNote : ''}`} >
+      <Show when={translator?.translations[props.note.id]?.status === 'loading'}>
+        <div class={styles.translationStatus}>Translating…</div>
+      </Show>
+      <Show when={translator?.translations[props.note.id]?.status === 'error'}>
+        <button
+          class={styles.translationRetry}
+          onClick={() => translator?.actions.translateNote(props.note)}
+        >
+          Translation failed — retry
+        </button>
+      </Show>
+      <Show when={translator?.translations[props.note.id]?.status === 'success' && translator?.translations[props.note.id]?.text}>
+        <div class={styles.translation}>
+          <div class={styles.translationLabel}>
+            Translation ({translator?.translations[props.note.id]?.targetLanguage})
+          </div>
+          <div>{translator?.translations[props.note.id]?.text}</div>
+        </div>
+      </Show>
       <For each={content}>
         {(item, index) => renderContent(item, index(), content.length)}
       </For>

--- a/src/contexts/TranslatorContext.tsx
+++ b/src/contexts/TranslatorContext.tsx
@@ -5,19 +5,49 @@ import {
   useContext
 } from "solid-js";
 import { IntlProvider } from "@cookbook/solid-intl";
+import { PrimalNote } from "../types/primal";
+
+export type NoteTranslation = {
+  status: 'loading' | 'success' | 'error',
+  text?: string,
+  targetLanguage: string,
+  error?: string,
+};
 
 
 export type TranslatorContextStore = {
   locale: string,
   messages: Record<string, string>,
+  translationLanguage: string,
+  translations: Record<string, NoteTranslation>,
   actions: {
     setLocale: (locale: string) => void,
+    setTranslationLanguage: (locale: string) => void,
+    translateNote: (note: Pick<PrimalNote, 'id' | 'content'>) => Promise<void>,
+    clearTranslation: (noteId: string) => void,
   },
 }
+
+const translationLanguageKey = 'primal.translationLanguage';
+
+const getDefaultTranslationLanguage = () => {
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem(translationLanguageKey);
+    if (stored) return stored;
+  }
+
+  if (typeof navigator !== 'undefined') {
+    return (navigator.language || 'en').split('-')[0].toLowerCase();
+  }
+
+  return 'en';
+};
 
 const initialData = {
   locale: 'en',
   messages: {},
+  translationLanguage: getDefaultTranslationLanguage(),
+  translations: {},
 };
 
 export const TranslatorContext = createContext<TranslatorContextStore>();
@@ -28,12 +58,75 @@ export function TranslatorProvider(props: { children: JSXElement }) {
     updateStore('locale', () => locale);
   };
 
+  const setTranslationLanguage = (locale: string) => {
+    const normalized = locale.trim().toLowerCase();
+    if (!normalized) return;
+
+    updateStore('translationLanguage', () => normalized);
+    window.localStorage.setItem(translationLanguageKey, normalized);
+  };
+
+  const translateNote = async (note: Pick<PrimalNote, 'id' | 'content'>) => {
+    const source = (note.content || '').trim();
+    const targetLanguage = store.translationLanguage;
+
+    if (!source) return;
+    if (store.translations[note.id]?.status === 'loading') return;
+
+    updateStore('translations', note.id, () => ({
+      status: 'loading',
+      targetLanguage,
+    }));
+
+    try {
+      // MyMemory accepts public requests from the browser and keeps this feature
+      // usable without requiring Primal to proxy or store a provider API key.
+      const query = encodeURIComponent(source.slice(0, 5_000));
+      const response = await fetch(
+        `https://api.mymemory.translated.net/get?q=${query}&langpair=auto|${encodeURIComponent(targetLanguage)}`,
+      );
+
+      if (!response.ok) {
+        throw new Error(`Translation service returned ${response.status}`);
+      }
+
+      const result = await response.json() as {
+        responseData?: { translatedText?: string },
+        responseStatus?: number,
+      };
+      const translatedText = result.responseData?.translatedText?.trim();
+
+      if (!translatedText || result.responseStatus === 403) {
+        throw new Error('The translation service did not return a translation');
+      }
+
+      updateStore('translations', note.id, () => ({
+        status: 'success',
+        text: translatedText,
+        targetLanguage,
+      }));
+    } catch (error) {
+      updateStore('translations', note.id, () => ({
+        status: 'error',
+        targetLanguage,
+        error: error instanceof Error ? error.message : 'Translation failed',
+      }));
+    }
+  };
+
+  const clearTranslation = (noteId: string) => {
+    updateStore('translations', noteId, undefined);
+  };
+
 // STORES ---------------------------------------
 
 const [store, updateStore] = createStore<TranslatorContextStore>({
   ...initialData,
   actions: {
     setLocale,
+    setTranslationLanguage,
+    translateNote,
+    clearTranslation,
   },
 });
 

--- a/src/pages/Settings/Appearance.tsx
+++ b/src/pages/Settings/Appearance.tsx
@@ -9,10 +9,12 @@ import { A } from '@solidjs/router';
 import PageTitle from '../../components/PageTitle/PageTitle';
 import CheckBox from '../../components/Checkbox/CheckBox';
 import { useSettingsContext } from '../../contexts/SettingsContext';
+import { useTranslatorContext } from '../../contexts/TranslatorContext';
 
 const Appearance: Component = () => {
 
   const settings = useSettingsContext();
+  const translator = useTranslatorContext();
   const intl = useIntl();
 
   return (
@@ -30,6 +32,28 @@ const Appearance: Component = () => {
         </div>
 
         <ThemeChooser />
+
+        <div class={styles.translationSettings}>
+          <div class={styles.translationTitle}>Post translation language</div>
+          <select
+            class={styles.translationSelect}
+            value={translator?.translationLanguage || 'en'}
+            onChange={(event) => translator?.actions.setTranslationLanguage(event.currentTarget.value)}
+          >
+            <option value="en">English</option>
+            <option value="es">Español</option>
+            <option value="fr">Français</option>
+            <option value="de">Deutsch</option>
+            <option value="it">Italiano</option>
+            <option value="pt">Português</option>
+            <option value="ja">日本語</option>
+            <option value="ko">한국어</option>
+            <option value="zh">中文</option>
+          </select>
+          <div class={styles.settingsDescription}>
+            Choose the language used when you translate a post from its context menu.
+          </div>
+        </div>
 
         <div>
           <CheckBox

--- a/src/pages/Settings/Settings.module.scss
+++ b/src/pages/Settings/Settings.module.scss
@@ -1108,6 +1108,31 @@
   line-height: 16px;
 }
 
+.translationSettings {
+  margin-block: 24px;
+  padding-block: 16px;
+  border-top: 1px solid var(--devider);
+  border-bottom: 1px solid var(--devider);
+}
+
+.translationTitle {
+  margin-bottom: 8px;
+  color: var(--text-secondary);
+  font-size: 16px;
+  font-weight: 500;
+}
+
+.translationSelect {
+  min-width: 220px;
+  height: 36px;
+  padding-inline: 10px;
+  border: 1px solid var(--subtile-devider);
+  border-radius: 8px;
+  color: var(--text-secondary);
+  background-color: var(--background-input);
+  font-size: 15px;
+}
+
 
 .devToolsList {
   display: flex;


### PR DESCRIPTION
## Summary

- Add a Translate action to the note context menu.
- Let users choose a target language in Appearance settings.
- Show loading, translated, and retry states while keeping the original post visible.

Translations are requested only when the user selects Translate and use the public MyMemory endpoint without storing a provider key.

close #133