### PR TITLE
Fix zap request encoding

### DIFF
--- a/src/lib/zap.ts
+++ b/src/lib/zap.ts
@@ -98,7 +98,7 @@ export const zapNote = async (
   try {
     const signedEvent = await signEvent(zapReq);
 
-    const event = encodeURIComponent(JSON.stringify(signedEvent));
+    const event = JSON.stringify(signedEvent);
 
     const url = new URL(callback);
     url.searchParams.set('amount', String(sats));
@@ -165,7 +165,7 @@ export const zapArticle = async (
   try {
     const signedEvent = await signEvent(zapReq);
 
-    const event = encodeURIComponent(JSON.stringify(signedEvent));
+    const event = JSON.stringify(signedEvent);
 
     const url = new URL(callback);
     url.searchParams.set('amount', String(sats));
@@ -223,7 +223,7 @@ export const zapProfile = async (
   try {
     const signedEvent = await signEvent(zapReq);
 
-    const event = encodeURIComponent(JSON.stringify(signedEvent));
+    const event = JSON.stringify(signedEvent);
 
     const url = new URL(callback);
     url.searchParams.set('amount', String(sats));
@@ -300,7 +300,7 @@ export const zapSubscription = async (
   try {
     const signedEvent = await signEvent(zapReq);
 
-    const event = encodeURIComponent(JSON.stringify(signedEvent));
+    const event = JSON.stringify(signedEvent);
 
     const url = new URL(callback);
     url.searchParams.set('amount', String(sats));
@@ -367,7 +367,7 @@ export const zapDVM = async (
   try {
     const signedEvent = await signEvent(zapReq);
 
-    const event = encodeURIComponent(JSON.stringify(signedEvent));
+    const event = JSON.stringify(signedEvent);
 
     const url = new URL(callback);
     url.searchParams.set('amount', String(sats));
@@ -434,7 +434,7 @@ export const zapStream = async (
   try {
     const signedEvent = await signEvent(zapReq);
 
-    const event = encodeURIComponent(JSON.stringify(signedEvent));
+    const event = JSON.stringify(signedEvent);
 
     const url = new URL(callback);
     url.searchParams.set('amount', String(sats));
@@ -566,7 +566,7 @@ export const zapVote = async (
   try {
     const signedEvent = await signEvent(zapReq);
 
-    const event = encodeURIComponent(JSON.stringify(signedEvent));
+    const event = JSON.stringify(signedEvent);
 
     const url = new URL(callback);
     url.searchParams.set('amount', String(sats));


### PR DESCRIPTION
## Summary

- stop pre-encoding signed NIP-57 zap requests before adding them to `URLSearchParams`
- apply the fix consistently to note, article, profile, subscription, DVM, stream, and poll-vote zaps

## Root cause

The callback construction was migrated from string interpolation to `URLSearchParams`, but retained the existing `encodeURIComponent` call. Because `URLSearchParams` performs query encoding itself, the percent signs were encoded a second time and callback servers received an encoded string rather than zap-request JSON after parsing the query once.

## Impact

LNURL callback servers now receive the signed zap request as JSON after normal query parsing, while callback URLs with existing parameters remain intact.

## Validation

- deterministic callback-serialization harness covering all seven zap paths
- `npm run build`
- `git -c core.whitespace=cr-at-eol diff --check`

## Existing issue

`tsc --noEmit` still reports the pre-existing syntax error `src/components/PrimalMarkdown/MarkdownEditor.tsx(78,1): error TS1005: '}' expected`; that file is unchanged by this PR.
