### PR TITLE
feat: add inline note translation with LibreTranslate support

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "serve": "vite preview",
     "host": "vite preview --host",
     "extract": "formatjs extract",
-    "compile": "formatjs compile"
+    "compile": "formatjs compile",
+    "check:translation": "node scripts/check-translation.mjs"
   },
   "license": "MIT",
   "devDependencies": {

--- a/scripts/check-translation.mjs
+++ b/scripts/check-translation.mjs
@@ -1,0 +1,349 @@
+/**
+ * Unit tests for the note-translation module (src/lib/translation.ts).
+ *
+ * Covers:
+ *   - entity-protection mask/unmask round-trip (URLs, nostr refs, hashtags,
+ *     @mentions, lightning invoices)
+ *   - de-duplication and tolerant restore of placeholders
+ *   - the translation service (URL/body construction, response parsing, errors)
+ *   - the high-level translate pipeline (cache → protect → translate → restore)
+ *   - bounded cache eviction
+ *
+ * Run with:  node scripts/check-translation.mjs
+ *
+ * The module under test is compiled from TypeScript in-process using the
+ * project's own `typescript` devDependency, so we exercise the shipped source
+ * rather than a forked copy.
+ */
+import { createRequire } from 'node:module';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+const ts = require('typescript');
+
+const compileModule = (relPath) => {
+  const source = readFileSync(new URL(relPath, import.meta.url), 'utf8');
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      esModuleInterop: true,
+    },
+    fileName: relPath,
+  });
+  return outputText;
+};
+
+const dir = mkdtempSync(join(tmpdir(), 'primal-translation-test-'));
+const compiled = compileModule('../src/lib/translation.ts');
+const modPath = join(dir, 'translation.cjs');
+writeFileSync(modPath, compiled);
+
+const translation = require(modPath);
+
+// ---------------------------------------------------------------------------
+// Minimal test harness
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+const tests = [];
+
+// Tests are registered here and run at the bottom so async bodies are awaited.
+const test = (name, fn) => tests.push({ name, fn });
+
+const assert = (cond, message) => {
+  if (!cond) throw new Error(message || 'assertion failed');
+};
+
+const assertEqual = (actual, expected, message) => {
+  if (actual !== expected) {
+    throw new Error(`${message || 'assertEqual failed'}\n    expected: ${JSON.stringify(expected)}\n    actual:   ${JSON.stringify(actual)}`);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Entity-protection round-trip
+// ---------------------------------------------------------------------------
+
+const {
+  protectEntities,
+  restoreEntities,
+  contentHash,
+  translateText,
+  translateNoteContent,
+  readCache,
+  writeCache,
+  hasTranslatableContent,
+  DEFAULT_TRANSLATE_ENDPOINT,
+} = translation;
+
+// Valid bech32 tokens (charset excludes b, i, o and 1 beyond the separator).
+const NPUB = 'npub1sg6plzptd64u62a878hep2kev88swjh3tw00gjsfl8f237lmu63q0uf63m';
+const NOTE = 'note1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq';
+const NEVENT = 'nevent1qqsrhuxx8l9ex335q7he0f09aej04zpazpl0ne2cgukyawd24mayt8gpp4mhxue69uhhytnc9e3k7mgpz4mhxue69uhkg6nzv9ejuumpv34kytnrdaks';
+const NADDR = 'naddr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq';
+const NPROFILE = 'nprofile1qqsrhuxx8l9ex335q7he0f09aej04zpazpl0ne2cgukyawd24mayt8gpp4mhxue69uhhytnc9e3k7mgpz4mhxue69uhkg6nzv9ejuumpv34kytnrdaks';
+
+// A "translator" that echoes its input unchanged — the identity case.
+const identityTranslate = (q) => q;
+
+test('mask/unmask round-trip is identity for a passthrough translator', () => {
+  const sample = [
+    `Check out https://primal.net/p/${NPUB} and follow @jack #nostr`,
+    `nostr:${NPUB} says hi`,
+    `Read nostr:${NOTE} and nostr:${NEVENT} plus ${NADDR} here https://example.com/path?a=b#frag.`,
+    'Lightning invoice lnbc10n1pjxq5t5dpa2mpqzqzqzqzqzqzqzqzqzqzqzqzqzqzqzqzqzqzqzqzqzqzqzq',
+    'hello world',
+    'email me at user@example.com (should not be treated as a mention)',
+  ].join('\n');
+
+  const { text, segments } = protectEntities(sample);
+  const restored = restoreEntities(text, segments);
+  assertEqual(restored, sample, 'round-trip must be lossless for a passthrough translator');
+});
+
+test('a bech32 reference inside a URL path round-trips intact', () => {
+  const sample = `see https://primal.net/p/${NPUB} today`;
+  const { text, segments } = protectEntities(sample);
+  const restored = restoreEntities(identityTranslate(text), segments);
+  assertEqual(restored, sample, 'npub embedded in a URL must not be corrupted');
+});
+
+test('entities are masked out of the protected text', () => {
+  const sample = `Visit https://primal.net and mention nostr:${NPUB} #tag @alice lnbc10n1x`;
+  const { text } = protectEntities(sample);
+
+  assert(!/https:\/\/primal\.net/.test(text), 'URL must be masked');
+  assert(!new RegExp(`nostr:${NPUB}`).test(text), 'nostr: reference must be masked');
+  assert(!/#tag/.test(text), 'hashtag must be masked');
+  assert(!/@alice/.test(text), '@mention must be masked');
+  assert(!/lnbc10n1x/.test(text), 'lightning invoice must be masked');
+  assert(/⟦\d+⟧/.test(text), 'placeholders must be present in protected text');
+});
+
+test('nostr bech32 references survive verbatim (all kinds)', () => {
+  const refs = [NPUB, NPROFILE, NOTE, NEVENT, NADDR];
+
+  const sample = `refs: ${refs.join(' ')}`;
+  const { text, segments } = protectEntities(sample);
+  const restored = restoreEntities(identityTranslate(text), segments);
+  assertEqual(restored, sample, 'all bech32 reference kinds must round-trip verbatim');
+});
+
+test('de-duplication reuses placeholders for identical entities', () => {
+  const sample = `nostr:${NPUB} and again nostr:${NPUB} and once more nostr:${NPUB}`;
+  const { text, segments } = protectEntities(sample);
+
+  const uniquePlaceholders = new Set(text.match(/⟦\d+⟧/g) || []);
+  assertEqual(uniquePlaceholders.size, 1, 'identical entities must map to one placeholder');
+  assertEqual(segments.length, 1, 'only one segment must be recorded');
+
+  const restored = restoreEntities(identityTranslate(text), segments);
+  assertEqual(restored, sample, 'de-duplicated restore must be lossless');
+});
+
+test('restore tolerates whitespace injected inside placeholders', () => {
+  const sample = 'check https://example.com now';
+  const { text, segments } = protectEntities(sample);
+  const mangled = text.replace(/⟦(\d+)⟧/g, '⟦ $1 ⟧');
+  const restored = restoreEntities(mangled, segments);
+  assertEqual(restored, sample, 'mangled placeholders must still restore');
+});
+
+test('leftover placeholders are removed', () => {
+  const sample = 'a #tag b';
+  const { segments } = protectEntities(sample);
+  const restored = restoreEntities('some text ⟦99⟧ left', segments);
+  assert(!/⟦/.test(restored), 'orphan placeholders must be stripped');
+});
+
+test('hasTranslatableContent distinguishes prose from entity-only notes', () => {
+  assertEqual(hasTranslatableContent('hello world'), true, 'prose must be translatable');
+  assertEqual(hasTranslatableContent('https://example.com'), false, 'URL-only must not be translatable');
+  assertEqual(hasTranslatableContent(`#tag @alice nostr:${NPUB}`), false, 'entity-only must not be translatable');
+  assertEqual(hasTranslatableContent(''), false, 'empty must not be translatable');
+});
+
+test('contentHash is stable and distinct', () => {
+  assertEqual(contentHash('hello'), contentHash('hello'), 'hash must be deterministic');
+  assert(contentHash('hello') !== contentHash('world'), 'hash must differ for different input');
+});
+
+// ---------------------------------------------------------------------------
+// Translation service (fetch is mocked below)
+// ---------------------------------------------------------------------------
+
+const makeFetchMock = (handler) => {
+  globalThis.fetch = async (url, init) => handler(String(url), init);
+};
+
+test('translateText builds the correct request and parses LibreTranslate response', async () => {
+  let captured;
+  makeFetchMock(async (url, init) => {
+    captured = { url, init };
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ translatedText: 'hola mundo', detectedLanguage: { language: 'en' } }),
+    };
+  });
+
+  const result = await translateText('hello world', 'es', 'https://lt.example.com', 'key123');
+
+  assertEqual(captured.url, 'https://lt.example.com/translate', 'endpoint must append /translate');
+  const body = JSON.parse(captured.init.body);
+  assertEqual(body.q, 'hello world', 'q must be the source text');
+  assertEqual(body.source, 'auto', 'source must be auto');
+  assertEqual(body.target, 'es', 'target must be passed through');
+  assertEqual(body.api_key, 'key123', 'api_key must be passed through');
+  assertEqual(result.translatedText, 'hola mundo', 'translatedText must be parsed');
+  assertEqual(result.detectedLanguage, 'en', 'detectedLanguage must be parsed');
+});
+
+test('translateText does not double the /translate path', async () => {
+  let captured;
+  makeFetchMock(async (url) => {
+    captured = url;
+    return { ok: true, status: 200, json: async () => ({ translatedText: 'x' }) };
+  });
+
+  await translateText('x', 'en', 'https://lt.example.com/translate', undefined);
+  assertEqual(captured, 'https://lt.example.com/translate', 'must not double /translate');
+});
+
+test('translateText omits api_key when absent', async () => {
+  let captured;
+  makeFetchMock(async (url, init) => {
+    captured = init;
+    return { ok: true, status: 200, json: async () => ({ translatedText: 'x' }) };
+  });
+
+  await translateText('x', 'en', 'https://lt.example.com', '');
+  const body = JSON.parse(captured.body);
+  assert(!('api_key' in body), 'api_key must be omitted when empty');
+});
+
+test('translateText supports the Lingva response shape', async () => {
+  makeFetchMock(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ translation: 'traduit' }),
+  }));
+
+  const result = await translateText('x', 'fr', 'https://lt.example.com', undefined);
+  assertEqual(result.translatedText, 'traduit', 'Lingva translation shape must be parsed');
+});
+
+test('translateText surfaces HTTP errors', async () => {
+  makeFetchMock(async () => ({ ok: false, status: 403, text: async () => 'forbidden' }));
+
+  let thrown = null;
+  try {
+    await translateText('x', 'en', 'https://lt.example.com', undefined);
+  } catch (e) {
+    thrown = e;
+  }
+  assert(thrown, 'must throw on non-ok response');
+  assertEqual(thrown.status, 403, 'must surface the HTTP status');
+});
+
+// ---------------------------------------------------------------------------
+// translateNoteContent pipeline + cache
+// ---------------------------------------------------------------------------
+
+const makeStorage = () => {
+  const map = new Map();
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => map.set(k, String(v)),
+    removeItem: (k) => map.delete(k),
+    key: (i) => Array.from(map.keys())[i] ?? null,
+    get length() { return map.size; },
+  };
+};
+
+test('translateNoteContent masks entities before translating and restores them after', async () => {
+  globalThis.localStorage = makeStorage();
+
+  const source = `La réunion est à https://example.com avec nostr:${NPUB} #plan @bob`;
+  let received = '';
+  makeFetchMock(async (url, init) => {
+    received = JSON.parse(init.body).q;
+    // The mock translator replaces all letters but leaves placeholders untouched.
+    const translated = received.replace(/[a-zà-ÿ]/gi, (c) => String.fromCharCode(c.charCodeAt(0) + 1));
+    return { ok: true, status: 200, json: async () => ({ translatedText: translated }) };
+  });
+
+  const result = await translateNoteContent(source, 'en', 'https://lt.example.com', undefined);
+
+  assert(!/https:\/\/example\.com/.test(received), 'URL must not be sent to the provider');
+  assert(!new RegExp(`nostr:${NPUB}`).test(received), 'nostr ref must not be sent to the provider');
+  assert(result.translatedText.includes('https://example.com'), 'URL must be restored verbatim');
+  assert(result.translatedText.includes(`nostr:${NPUB}`), 'nostr ref must be restored verbatim');
+  assert(result.translatedText.includes('#plan'), 'hashtag must be restored verbatim');
+  assert(result.translatedText.includes('@bob'), 'mention must be restored verbatim');
+});
+
+test('translateNoteContent caches results and does not re-fetch', async () => {
+  globalThis.localStorage = makeStorage();
+
+  let calls = 0;
+  makeFetchMock(async () => {
+    calls++;
+    return { ok: true, status: 200, json: async () => ({ translatedText: 'cache me' }) };
+  });
+
+  await translateNoteContent('unique cached note', 'en', 'https://lt.example.com', undefined);
+  await translateNoteContent('unique cached note', 'en', 'https://lt.example.com', undefined);
+
+  assertEqual(calls, 1, 'second call must hit the cache');
+  assert(readCache('unique cached note', 'en', 'https://lt.example.com'), 'cache must be populated');
+});
+
+test('cache evicts oldest entries beyond the bound', () => {
+  globalThis.localStorage = makeStorage();
+
+  const endpoint = 'https://lt.example.com';
+  const target = 'en';
+
+  // 205 entries > 200 bound. Timestamps increase with i, so entry 0 is oldest.
+  for (let i = 0; i < 205; i++) {
+    writeCache(`note ${i}`, target, endpoint, { translatedText: `t${i}`, detectedLanguage: '', ts: 1000 + i });
+  }
+
+  assert(!readCache('note 0', target, endpoint), 'oldest entry must be evicted');
+  assert(readCache('note 204', target, endpoint), 'newest entry must be retained');
+});
+
+// ---------------------------------------------------------------------------
+// Run registered tests (awaits async bodies), then summarize
+// ---------------------------------------------------------------------------
+
+for (const { name, fn } of tests) {
+  try {
+    await fn();
+    passed++;
+    console.log(`  PASS  ${name}`);
+  } catch (err) {
+    failed++;
+    failures.push({ name, err });
+    console.error(`  FAIL  ${name}`);
+    console.error(`        ${err && err.message ? err.message : err}`);
+  }
+}
+
+rmSync(dir, { recursive: true, force: true });
+
+console.log(`\n${passed} passed, ${failed} failed`);
+
+if (failed > 0) {
+  console.error('\nFailures:');
+  for (const f of failures) {
+    console.error(`  - ${f.name}: ${f.err && f.err.message ? f.err.message : f.err}`);
+  }
+  process.exit(1);
+}

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -53,6 +53,7 @@ const Moderation = lazy(() => import('./pages/Settings/Moderation'));
 const NostrWalletConnect = lazy(() => import('./pages/Settings/NostrWalletConnect'));
 const Menu = lazy(() => import('./pages/Settings/Menu'));
 const BlossomSettings = lazy(() => import('./pages/Settings/Blossom'));
+const TranslationSettings = lazy(() => import('./pages/Settings/Translation'));
 // const Landing = lazy(() => import('./pages/Landing'));
 const AppDownloadQr = lazy(() => import('./pages/appDownloadQr'));
 const EventQueuePage = lazy(() => import('./pages/EventQueue'));
@@ -166,6 +167,7 @@ const AppRouter: Component = () => {
             <Route path="/nwc" component={NostrWalletConnect} />
             <Route path="/devtools" component={DevTools} />
             <Route path="/uploads" component={Blossom} />
+            <Route path="/translation" component={TranslationSettings} />
           </Route>
           <Route path="/bookmarks" component={Bookmarks} />
           <Route path="/settings/profile" component={EditProfile} />

--- a/src/components/Note/Note.tsx
+++ b/src/components/Note/Note.tsx
@@ -3,6 +3,7 @@ import { batch, Component, createEffect, Match, on, onMount, Show, Switch } from
 import { PrimalNote, PrimalUser, TopZap, ZapOption } from '../../types/primal';
 import ParsedNote from '../ParsedNote/ParsedNote';
 import NoteFooter from './NoteFooter/NoteFooter';
+import NoteTranslate from '../NoteTranslate/NoteTranslate';
 
 import styles from './Note.module.scss';
 import { useThreadContext } from '../../contexts/ThreadContext';
@@ -19,7 +20,7 @@ import { date, veryLongDate } from '../../lib/dates';
 import { isPhone, uuidv4 } from '../../utils';
 import NoteTopZaps from './NoteTopZaps';
 import NoteTopZapsCompact from './NoteTopZapsCompact';
-import { addrRegexG, imageRegexG, linebreakRegex, noteRegex, urlRegexG } from '../../constants';
+import { addrRegexG, imageRegexG, Kind, linebreakRegex, noteRegex, urlRegexG } from '../../constants';
 import { TranslatorProvider } from '../../contexts/TranslatorContext';
 import { accountStore } from '../../stores/accountStore';
 import { useNavigate } from '@solidjs/router';
@@ -83,6 +84,12 @@ const Note: Component<NoteProps> = (props) => {
   });
 
   const noteType = () => props.noteType || 'feed';
+
+  // Only kind-1 notes (and reposts of them) are eligible for inline translation;
+  // long-form articles and drafts are excluded.
+  const isTextKind = () => {
+    return props.note.post.kind === Kind.Text || props.note.post.kind === Kind.Repost;
+  };
 
   const repost = () => props.note.repost;
 
@@ -414,6 +421,10 @@ const Note: Component<NoteProps> = (props) => {
               />
             </div>
 
+            <Show when={isTextKind()}>
+              <NoteTranslate note={props.note} />
+            </Show>
+
             <div class={styles.topZaps}>
               <NoteTopZaps
                 topZaps={reactionsState.topZapsFeed}
@@ -557,6 +568,10 @@ const Note: Component<NoteProps> = (props) => {
             />
           </div>
 
+          <Show when={isTextKind()}>
+            <NoteTranslate note={props.note} />
+          </Show>
+
           <NoteTopZapsCompact
             note={props.note}
             action={() => openReactionModal('zaps')}
@@ -643,6 +658,10 @@ const Note: Component<NoteProps> = (props) => {
                   footerSize="short"
                 />
               </div>
+
+              <Show when={isTextKind()}>
+                <NoteTranslate note={props.note} />
+              </Show>
 
               <NoteTopZapsCompact
                 note={props.note}

--- a/src/components/NoteTranslate/NoteTranslate.module.scss
+++ b/src/components/NoteTranslate/NoteTranslate.module.scss
@@ -1,0 +1,85 @@
+.noteTranslate {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+}
+
+.translation {
+  padding: 8px 10px;
+  border-left: 3px solid var(--accent);
+  background: var(--background-card);
+  border-radius: 4px;
+  font-size: 15px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text-primary);
+}
+
+.error {
+  padding: 6px 10px;
+  font-size: 13px;
+  color: var(--warning-color);
+  background: rgba(229, 72, 77, 0.08);
+  border-radius: 4px;
+}
+
+.translateButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  background: transparent;
+  border: none;
+  padding: 4px 8px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--accent-links, var(--accent));
+  border-radius: 4px;
+  transition: background 0.15s ease;
+
+  &:hover:not(:disabled) {
+    background: rgba(255, 138, 0, 0.1);
+  }
+
+  &:disabled {
+    cursor: progress;
+    opacity: 0.7;
+  }
+}
+
+.active {
+  color: var(--text-secondary);
+}
+
+.icon {
+  font-size: 14px;
+  line-height: 1;
+}
+
+.label {
+  line-height: 1;
+}
+
+.detected {
+  color: var(--text-secondary);
+  font-weight: 400;
+  font-size: 12px;
+}
+
+.spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--accent);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: noteTranslateSpin 0.6s linear infinite;
+}
+
+@keyframes noteTranslateSpin {
+  to { transform: rotate(360deg); }
+}

--- a/src/components/NoteTranslate/NoteTranslate.tsx
+++ b/src/components/NoteTranslate/NoteTranslate.tsx
@@ -1,0 +1,117 @@
+import { Component, createSignal, Show } from 'solid-js';
+import { useIntl } from '@cookbook/solid-intl';
+import { PrimalNote } from '../../types/primal';
+import {
+  hasTranslatableContent,
+  translateNoteContent,
+  TranslationError,
+} from '../../lib/translation';
+import { loadTranslationSettings } from '../../lib/translationSettings';
+import { noteTranslation as t } from '../../translations';
+import { hookForDev } from '../../lib/devTools';
+
+import styles from './NoteTranslate.module.scss';
+
+type TranslateState = 'idle' | 'loading' | 'done' | 'error';
+
+/**
+ * Inline Translate / Show-original control rendered below kind-1 note content
+ * (issue #133).
+ *
+ * - "Translate" fetches a translation and renders it inline.
+ * - "Show original" collapses the translation back to the source text.
+ * - Shows the detected source language when the provider returns it.
+ * - Translations are cached client-side (see lib/translation.ts).
+ * - Fails gracefully with a short message when the service is unavailable.
+ */
+const NoteTranslate: Component<{ note: PrimalNote, id?: string }> = (props) => {
+
+  const intl = useIntl();
+
+  const [state, setState] = createSignal<TranslateState>('idle');
+  const [translated, setTranslated] = createSignal('');
+  const [detectedLang, setDetectedLang] = createSignal('');
+  const [errorMsg, setErrorMsg] = createSignal('');
+
+  const content = () => props.note.content || '';
+
+  const shouldShow = () => {
+    const settings = loadTranslationSettings();
+    if (!settings.enabled) return false;
+    if (content().trim().length === 0) return false;
+    return hasTranslatableContent(content());
+  };
+
+  const onToggle = async (e: MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    // "Show original" — collapse the translation.
+    if (state() === 'done') {
+      setState('idle');
+      return;
+    }
+
+    if (state() === 'loading') return;
+
+    const settings = loadTranslationSettings();
+    if (!settings.enabled) return;
+
+    setState('loading');
+    setErrorMsg('');
+
+    try {
+      const result = await translateNoteContent(
+        content(),
+        settings.targetLang,
+        settings.endpoint,
+        settings.apiKey,
+      );
+      setTranslated(result.translatedText);
+      setDetectedLang(result.detectedLanguage || '');
+      setState('done');
+    } catch (err) {
+      const error = err as TranslationError;
+      setErrorMsg(error.message || intl.formatMessage(t.translateFailed));
+      setState('error');
+    }
+  };
+
+  return (
+    <Show when={shouldShow()}>
+      <div class={styles.noteTranslate} id={props.id}>
+        <Show when={state() === 'done'}>
+          <div class={styles.translation}>{translated()}</div>
+        </Show>
+
+        <Show when={state() === 'error'}>
+          <div class={styles.error}>{errorMsg()}</div>
+        </Show>
+
+        <button
+          class={`${styles.translateButton} ${state() === 'done' ? styles.active : ''}`}
+          onClick={onToggle}
+          disabled={state() === 'loading'}
+          title={intl.formatMessage(t.translateNote)}
+        >
+          <Show
+            when={state() !== 'loading'}
+            fallback={<span class={styles.spinner} />}
+          >
+            <span class={styles.icon} aria-hidden="true">{'\u{1F310}'}</span>
+          </Show>
+          <span class={styles.label}>
+            {state() === 'done'
+              ? intl.formatMessage(t.showOriginal)
+              : intl.formatMessage(t.translateNote)}
+          </span>
+          <Show when={state() === 'done' && detectedLang()}>
+            <span class={styles.detected}>{'\u00B7'} {detectedLang()}</span>
+          </Show>
+        </button>
+      </div>
+    </Show>
+  );
+};
+
+export default hookForDev(NoteTranslate);

--- a/src/lib/translation.ts
+++ b/src/lib/translation.ts
@@ -1,0 +1,371 @@
+/**
+ * Inline note translation for kind-1 notes (issue #133).
+ *
+ * Frontend-only, LibreTranslate-compatible. A note's raw text is sent to a
+ * user-configurable `/translate` endpoint after any entities that must survive
+ * translation verbatim (URLs, `nostr:`/bare bech32 references, hashtags,
+ * `@mentions` and lightning invoices) have been masked out. Translated text is
+ * then spliced back with those entities restored exactly as they appeared.
+ *
+ * This module is intentionally self-contained (no imports from the rest of the
+ * app) so its entity-protection and service logic can be unit-tested in
+ * isolation from the browser/DOM (see scripts/check-translation.mjs).
+ */
+
+/**
+ * Default public LibreTranslate-compatible endpoint. Self-hostable; users may
+ * override it (and supply an API key) under Settings → Note Translation.
+ */
+export const DEFAULT_TRANSLATE_ENDPOINT = 'https://libretranslate.com';
+
+/**
+ * Default target language derived from the browser locale, e.g. "en-US" → "en".
+ * LibreTranslate expects an ISO 639-1 code.
+ */
+export const DEFAULT_TRANSLATE_TARGET = (): string => {
+  const lang = (typeof navigator !== 'undefined' && navigator.language) || 'en';
+  return (lang.split('-')[0] || 'en').toLowerCase();
+};
+
+// ---------------------------------------------------------------------------
+// Entity protection (mask before translate, splice back verbatim after)
+// ---------------------------------------------------------------------------
+
+// The bech32 character set used by Nostr references (npub/nprofile/note/nevent/naddr).
+const BECH32_CHARS = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+
+const NOSTR_ENTITY_KINDS = 'npub|nprofile|note|nevent|naddr';
+
+/**
+ * Ordered protection patterns. Order matters: the most specific forms must be
+ * matched before the more generic ones so a `nostr:npub1…` reference is
+ * consumed whole before the bare-`npub1…` pattern ever sees it, and URLs are
+ * masked before hashtags so a `#fragment` inside a URL is not treated as a tag.
+ */
+const PROTECTED_PATTERNS: RegExp[] = [
+  // nostr:-prefixed bech32 references (most specific)
+  new RegExp(`nostr:(${NOSTR_ENTITY_KINDS})1[${BECH32_CHARS}]+`, 'gi'),
+  // URLs (with or without a leading nostr: prefix). Must run BEFORE bare bech32
+  // so a bech32 reference appearing inside a URL path is masked together with
+  // the URL as a single unit (otherwise the URL's placeholder would capture an
+  // already-masked inner placeholder and corrupt the restore).
+  /(?:nostr:)?https?:\/\/[^\s]+/gi,
+  // bare bech32 references
+  new RegExp(`\\b(${NOSTR_ENTITY_KINDS})1[${BECH32_CHARS}]+`, 'gi'),
+  // lightning invoices (keep them machine-readable)
+  /\blnbc[a-z0-9]+/gi,
+  // hashtags (leading boundary captured so the # is not a color/bare `#`)
+  /(?:^|\s)#[\p{L}\p{N}_]+/giu,
+  // @mentions
+  /(?:^|\s)@[\p{L}\p{N}_-]+/giu,
+];
+
+// Trailing punctuation that belongs to the surrounding sentence rather than a
+// URL. Peeled off in the URL protection callback so it still gets translated.
+const URL_TRAILING_PUNCTUATION = /[.,;:!?()[\]{}"'<>]+$/;
+
+export type ProtectedSegment = {
+  /** placeholder emitted into the text handed to the translator, e.g. `⟦0⟧` */
+  placeholder: string;
+  /** the original text to restore verbatim */
+  original: string;
+};
+
+export type ProtectedContent = {
+  /** text with all protected segments replaced by placeholders */
+  text: string;
+  /** ordered, de-duplicated list of protected segments */
+  segments: ProtectedSegment[];
+};
+
+const placeholderFor = (index: number) => `\u27E6${index}\u27E7`;
+
+const isUrlPattern = (re: RegExp) => re.source.includes('https?');
+
+/**
+ * Replace URLs, Nostr references, hashtags, @mentions and lightning invoices
+ * with sequential `⟦N⟧` placeholders so the translation provider never sees
+ * them. Identical entities are de-duplicated (reusing the same placeholder) to
+ * reduce the payload size and keep the restore step trivial.
+ */
+export const protectEntities = (content: string): ProtectedContent => {
+  const segments: ProtectedSegment[] = [];
+  let working = content;
+  let index = 0;
+
+  const protect = (original: string): string => {
+    const existing = segments.find((s) => s.original === original);
+    if (existing) return existing.placeholder;
+
+    const placeholder = placeholderFor(index);
+    segments.push({ placeholder, original });
+    index++;
+    return placeholder;
+  };
+
+  for (const pattern of PROTECTED_PATTERNS) {
+    working = working.replace(pattern, (match) => {
+      // For URLs, peel trailing sentence punctuation and keep it in place so it
+      // is still translated rather than glued onto the restored link.
+      if (isUrlPattern(pattern)) {
+        const trailing = (match.match(URL_TRAILING_PUNCTUATION) || [''])[0];
+        const url = trailing ? match.slice(0, match.length - trailing.length) : match;
+        return protect(url) + trailing;
+      }
+      return protect(match);
+    });
+  }
+
+  return { text: working, segments };
+};
+
+/**
+ * Restore protected segments into the translated text. Tolerates translators
+ * that insert whitespace inside the `⟦N⟧` markers, then removes any leftover
+ * markers as a final safety net.
+ */
+export const restoreEntities = (
+  translated: string,
+  segments: ProtectedSegment[],
+): string => {
+  let result = translated;
+
+  for (const segment of segments) {
+    const num = (segment.placeholder.match(/\d+/) || [''])[0];
+    if (!num) continue;
+    const re = new RegExp(`\\u27E6\\s*${num}\\s*\\u27E7`, 'g');
+    result = result.replace(re, segment.original);
+  }
+
+  return result.replace(/\u27E6\s*\d+\s*\u27E7/g, '');
+};
+
+/**
+ * Whether there is any prose left to translate once entities are masked out.
+ * Used to hide the Translate control on notes that are only URLs, images,
+ * references, etc.
+ */
+export const hasTranslatableContent = (content: string): boolean => {
+  const { text } = protectEntities(content);
+  return /\p{L}/u.test(text);
+};
+
+// ---------------------------------------------------------------------------
+// Content hashing (cache keys)
+// ---------------------------------------------------------------------------
+
+/**
+ * Stable, dependency-free hash (djb2) used only for cache keys — not for
+ * security.
+ */
+export const contentHash = (text: string): string => {
+  let hash = 5381;
+  for (let i = 0; i < text.length; i++) {
+    hash = ((hash << 5) + hash) + text.charCodeAt(i);
+    hash = hash & hash; // keep within 32-bit
+  }
+  return (hash >>> 0).toString(16);
+};
+
+// ---------------------------------------------------------------------------
+// Client-side cache with bounded eviction
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY = 'primal:translation:cache';
+const CACHE_MAX_ENTRIES = 200;
+
+export type CachedTranslation = {
+  translatedText: string;
+  detectedLanguage: string;
+  ts: number;
+};
+
+type CacheStore = Record<string, CachedTranslation>;
+
+const getLocalStorage = (): Storage | undefined => {
+  try {
+    return typeof localStorage !== 'undefined' ? localStorage : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const readCacheStore = (): CacheStore => {
+  const ls = getLocalStorage();
+  if (!ls) return {};
+  try {
+    const raw = ls.getItem(CACHE_KEY);
+    return raw ? (JSON.parse(raw) as CacheStore) : {};
+  } catch {
+    return {};
+  }
+};
+
+const writeCacheStore = (store: CacheStore): void => {
+  const ls = getLocalStorage();
+  if (!ls) return;
+  try {
+    ls.setItem(CACHE_KEY, JSON.stringify(store));
+  } catch {
+    /* storage full / unavailable — non-fatal, translation still works */
+  }
+};
+
+/** Evict the oldest entries until the store is within CACHE_MAX_ENTRIES. */
+const evictCache = (store: CacheStore): void => {
+  const entries = Object.entries(store);
+  if (entries.length <= CACHE_MAX_ENTRIES) return;
+  entries.sort((a, b) => (a[1].ts || 0) - (b[1].ts || 0));
+  const toRemove = entries.length - CACHE_MAX_ENTRIES;
+  for (let i = 0; i < toRemove; i++) delete store[entries[i][0]];
+};
+
+const cacheKeyFor = (sourceText: string, targetLang: string, endpoint: string) =>
+  contentHash(`${endpoint}|${targetLang}|${sourceText}`);
+
+export const readCache = (
+  sourceText: string,
+  targetLang: string,
+  endpoint: string,
+): CachedTranslation | undefined => {
+  return readCacheStore()[cacheKeyFor(sourceText, targetLang, endpoint)];
+};
+
+export const writeCache = (
+  sourceText: string,
+  targetLang: string,
+  endpoint: string,
+  value: CachedTranslation,
+): void => {
+  const store = readCacheStore();
+  store[cacheKeyFor(sourceText, targetLang, endpoint)] = {
+    ...value,
+    ts: value.ts || Date.now(),
+  };
+  evictCache(store);
+  writeCacheStore(store);
+};
+
+// ---------------------------------------------------------------------------
+// LibreTranslate-compatible API call
+// ---------------------------------------------------------------------------
+
+export type TranslationResult = {
+  translatedText: string;
+  detectedLanguage: string;
+};
+
+export type TranslationError = {
+  message: string;
+  status?: number;
+};
+
+/**
+ * POST to a LibreTranslate-compatible `/translate` endpoint.
+ *
+ * Request body: `{ q, source: "auto", target, format: "text", api_key? }`.
+ * Response:    `{ translatedText, detectedLanguage?: { language } | string }`.
+ *
+ * Also tolerates the Lingva (`translation`) shape, a drop-in-compatible
+ * alternative users sometimes point the endpoint at.
+ */
+export const translateText = async (
+  text: string,
+  targetLang: string,
+  endpoint: string,
+  apiKey?: string,
+): Promise<TranslationResult> => {
+  const base = (endpoint || DEFAULT_TRANSLATE_ENDPOINT).trim().replace(/\/+$/, '');
+  const url = /\/translate$/.test(base) ? base : `${base}/translate`;
+
+  const body: Record<string, unknown> = {
+    q: text,
+    source: 'auto',
+    target: targetLang,
+    format: 'text',
+  };
+  if (apiKey && apiKey.trim().length > 0) {
+    body.api_key = apiKey.trim();
+  }
+
+  let resp: Response;
+  try {
+    resp = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    throw {
+      message: `Could not reach the translation service (${base}). Check the endpoint in Settings → Note Translation or your connection.`,
+    } as TranslationError;
+  }
+
+  if (!resp.ok) {
+    let detail = '';
+    try {
+      detail = (await resp.text()).slice(0, 200);
+    } catch {
+      /* ignore */
+    }
+    throw {
+      message: `Translation service returned an error (HTTP ${resp.status})${detail ? `: ${detail}` : ''}`,
+      status: resp.status,
+    } as TranslationError;
+  }
+
+  let data: any;
+  try {
+    data = await resp.json();
+  } catch {
+    throw { message: 'Translation service returned a malformed response.' } as TranslationError;
+  }
+
+  if (typeof data.translatedText === 'string') {
+    const detected = data.detectedLanguage;
+    return {
+      translatedText: data.translatedText,
+      detectedLanguage:
+        (typeof detected === 'string' && detected) ||
+        (detected && detected.language) ||
+        '',
+    };
+  }
+
+  if (typeof data.translation === 'string') {
+    return { translatedText: data.translation, detectedLanguage: '' };
+  }
+
+  throw { message: 'Translation service returned an unexpected response shape.' } as TranslationError;
+};
+
+/**
+ * High-level pipeline used by the UI: cache lookup → protect entities →
+ * translate → restore entities → cache write.
+ */
+export const translateNoteContent = async (
+  content: string,
+  targetLang: string,
+  endpoint: string,
+  apiKey?: string,
+): Promise<TranslationResult> => {
+  const cached = readCache(content, targetLang, endpoint);
+  if (cached) {
+    return {
+      translatedText: cached.translatedText,
+      detectedLanguage: cached.detectedLanguage,
+    };
+  }
+
+  const { text: protectedText, segments } = protectEntities(content);
+  const result = await translateText(protectedText, targetLang, endpoint, apiKey);
+  const translatedText = restoreEntities(result.translatedText, segments);
+
+  writeCache(content, targetLang, endpoint, {
+    translatedText,
+    detectedLanguage: result.detectedLanguage,
+    ts: Date.now(),
+  });
+
+  return { translatedText, detectedLanguage: result.detectedLanguage };
+};

--- a/src/lib/translationSettings.ts
+++ b/src/lib/translationSettings.ts
@@ -1,0 +1,48 @@
+import { DEFAULT_TRANSLATE_ENDPOINT, DEFAULT_TRANSLATE_TARGET } from './translation';
+
+/**
+ * User-configurable note-translation settings (issue #133).
+ *
+ * Persisted in `localStorage` so the feature stays frontend-only and works for
+ * anonymous users too (the Nostr-backed SettingsContext requires a logged-in
+ * account). Follows the same save/load-with-guards pattern as lib/localStore.ts.
+ */
+
+const SETTINGS_KEY = 'primal:translation:settings';
+
+export type TranslationSettings = {
+  /** LibreTranslate-compatible base URL, e.g. https://libretranslate.com */
+  endpoint: string;
+  /** optional API key for the translation service */
+  apiKey: string;
+  /** target language ISO 639-1 code, e.g. "en", "es", "de" */
+  targetLang: string;
+  /** whether the inline Translate control is shown on kind-1 notes */
+  enabled: boolean;
+};
+
+export const defaultTranslationSettings = (): TranslationSettings => ({
+  endpoint: DEFAULT_TRANSLATE_ENDPOINT,
+  apiKey: '',
+  targetLang: DEFAULT_TRANSLATE_TARGET(),
+  enabled: true,
+});
+
+export const loadTranslationSettings = (): TranslationSettings => {
+  try {
+    const raw = localStorage.getItem(SETTINGS_KEY);
+    if (!raw) return defaultTranslationSettings();
+    const parsed = JSON.parse(raw) as Partial<TranslationSettings>;
+    return { ...defaultTranslationSettings(), ...parsed };
+  } catch {
+    return defaultTranslationSettings();
+  }
+};
+
+export const saveTranslationSettings = (settings: TranslationSettings): void => {
+  try {
+    localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+  } catch {
+    /* storage unavailable — non-fatal */
+  }
+};

--- a/src/pages/Settings/Menu.tsx
+++ b/src/pages/Settings/Menu.tsx
@@ -2,7 +2,7 @@ import { Component, Show } from 'solid-js';
 import styles from './Settings.module.scss';
 
 import { useIntl } from '@cookbook/solid-intl';
-import { settings as t, actions as tActions } from '../../translations';
+import { settings as t, actions as tActions, noteTranslation as tTr } from '../../translations';
 import PageCaption from '../../components/PageCaption/PageCaption';
 import { A, useNavigate } from '@solidjs/router';
 import ButtonPrimary from '../../components/Buttons/ButtonPrimary';
@@ -80,6 +80,11 @@ const Menu: Component = () => {
 
         <A href="/settings/network">
           {intl.formatMessage(t.network.title)}
+          <div class={styles.chevron}></div>
+        </A>
+
+        <A href="/settings/translation">
+          {intl.formatMessage(tTr.settingsTitle)}
           <div class={styles.chevron}></div>
         </A>
 

--- a/src/pages/Settings/Translation.tsx
+++ b/src/pages/Settings/Translation.tsx
@@ -1,0 +1,107 @@
+import { Component, createSignal } from 'solid-js';
+import styles from './Settings.module.scss';
+
+import { useIntl } from '@cookbook/solid-intl';
+import { settings as t, noteTranslation as tTr } from '../../translations';
+import PageCaption from '../../components/PageCaption/PageCaption';
+import { A } from '@solidjs/router';
+import PageTitle from '../../components/PageTitle/PageTitle';
+import ButtonSecondary from '../../components/Buttons/ButtonSecondary';
+import CheckBox from '../../components/Checkbox/CheckBox';
+import { useToastContext } from '../../components/Toaster/Toaster';
+import {
+  loadTranslationSettings,
+  saveTranslationSettings,
+  TranslationSettings,
+} from '../../lib/translationSettings';
+import { DEFAULT_TRANSLATE_TARGET } from '../../lib/translation';
+
+const Translation: Component = () => {
+  const intl = useIntl();
+  const toast = useToastContext();
+
+  const [cfg, setCfg] = createSignal<TranslationSettings>(loadTranslationSettings());
+
+  const update = (patch: Partial<TranslationSettings>) => {
+    setCfg((prev) => ({ ...prev, ...patch }));
+  };
+
+  const onSave = () => {
+    saveTranslationSettings(cfg());
+    toast?.sendSuccess(intl.formatMessage(tTr.settingsSaved));
+  };
+
+  return (
+    <div>
+      <PageTitle title={`${intl.formatMessage(tTr.settingsTitle)} ${intl.formatMessage(t.title)}`} />
+
+      <PageCaption>
+        <A href='/settings' >{intl.formatMessage(t.index.title)}</A>:&nbsp;
+        <div>{intl.formatMessage(tTr.settingsTitle)}</div>
+      </PageCaption>
+
+      <div class={styles.settingsContent}>
+        <div class={styles.bigCaption}>
+          {intl.formatMessage(tTr.settingsTitle)}
+        </div>
+
+        <div class={styles.settingsCaption}>
+          <CheckBox
+            checked={cfg().enabled}
+            onChange={(checked: boolean) => update({ enabled: checked })}
+            label={intl.formatMessage(tTr.settingsEnabled)}
+          />
+        </div>
+
+        <div class={`${styles.settingsCaption} ${styles.secondCaption}`}>
+          {intl.formatMessage(tTr.settingsEndpoint)}
+        </div>
+        <div class={styles.relayInput}>
+          <input
+            type='text'
+            value={cfg().endpoint}
+            placeholder='https://libretranslate.com'
+            onInput={(e) => update({ endpoint: e.currentTarget.value })}
+          />
+        </div>
+
+        <div class={`${styles.settingsCaption} ${styles.secondCaption}`}>
+          {intl.formatMessage(tTr.settingsApiKey)}
+        </div>
+        <div class={styles.relayInput}>
+          <input
+            type='password'
+            value={cfg().apiKey}
+            placeholder=''
+            onInput={(e) => update({ apiKey: e.currentTarget.value })}
+          />
+        </div>
+
+        <div class={`${styles.settingsCaption} ${styles.secondCaption}`}>
+          {intl.formatMessage(tTr.settingsTargetLang)}
+        </div>
+        <div class={styles.relayInput}>
+          <input
+            type='text'
+            style={{ width: '100px' }}
+            value={cfg().targetLang}
+            placeholder={DEFAULT_TRANSLATE_TARGET()}
+            onInput={(e) => update({ targetLang: e.currentTarget.value.toLowerCase().trim() })}
+          />
+        </div>
+
+        <div class={styles.moderationDescription} style={{ 'margin-top': '12px' }}>
+          {intl.formatMessage(tTr.settingsHelp)}
+        </div>
+
+        <div style={{ 'margin-top': '16px' }}>
+          <ButtonSecondary onClick={onSave}>
+            {intl.formatMessage(t.save)}
+          </ButtonSecondary>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Translation;

--- a/src/translations.ts
+++ b/src/translations.ts
@@ -750,6 +750,64 @@ export const actions = {
   },
 };
 
+export const noteTranslation = {
+  translateNote: {
+    id: 'noteTranslation.translateNote',
+    defaultMessage: 'Translate',
+    description: 'Button label to translate a note',
+  },
+  showOriginal: {
+    id: 'noteTranslation.showOriginal',
+    defaultMessage: 'Show original',
+    description: 'Button label to show the original (untranslated) note text',
+  },
+  translateFailed: {
+    id: 'noteTranslation.translateFailed',
+    defaultMessage: 'Translation failed. Check your translation settings and try again.',
+    description: 'Error message shown when note translation fails',
+  },
+  settingsTitle: {
+    id: 'noteTranslation.settingsTitle',
+    defaultMessage: 'Note Translation',
+    description: 'Title of the note translation settings page',
+  },
+  settingsCaption: {
+    id: 'noteTranslation.settingsCaption',
+    defaultMessage: 'Configure the translation service used for the inline Translate button on notes.',
+    description: 'Caption for the note translation settings page',
+  },
+  settingsEnabled: {
+    id: 'noteTranslation.settingsEnabled',
+    defaultMessage: 'Show translate button on notes',
+    description: 'Label for the toggle that enables the inline translate feature',
+  },
+  settingsEndpoint: {
+    id: 'noteTranslation.settingsEndpoint',
+    defaultMessage: 'Translation service URL',
+    description: 'Label for the translation API endpoint input',
+  },
+  settingsApiKey: {
+    id: 'noteTranslation.settingsApiKey',
+    defaultMessage: 'API key (optional)',
+    description: 'Label for the optional translation API key input',
+  },
+  settingsTargetLang: {
+    id: 'noteTranslation.settingsTargetLang',
+    defaultMessage: 'Target language',
+    description: 'Label for the target language input',
+  },
+  settingsHelp: {
+    id: 'noteTranslation.settingsHelp',
+    defaultMessage: 'Uses a LibreTranslate-compatible service. The default points to the public LibreTranslate instance; for reliability and privacy, consider self-hosting your own or using a paid key. URLs, Nostr references, hashtags, @mentions and lightning invoices are never sent to the service.',
+    description: 'Help text explaining the translation service configuration',
+  },
+  settingsSaved: {
+    id: 'noteTranslation.settingsSaved',
+    defaultMessage: 'Translation settings saved',
+    description: 'Toast message when translation settings are saved',
+  },
+};
+
 export const branding = {
   id: 'branding',
   defaultMessage: 'Primal',


### PR DESCRIPTION
## Summary

Adds inline note translation for kind-1 notes. A **Translate / Show original** toggle renders below note content in the feed and thread (primary + reply) views; translated text appears inline, with the detected source language shown when the provider returns it.

close #133

## Approach

- **Frontend-only, LibreTranslate-compatible** — configurable endpoint (defaults to the public LibreTranslate instance), optional API key, and target language, persisted in `localStorage` under Settings → Note Translation.
- **Entity protection (the hard part)** — before anything reaches the provider, URLs, `nostr:`/bare bech32 refs (`npub`/`nprofile`/`note`/`nevent`/`naddr`), hashtags, `@mentions` and `lnbc` invoices are masked with placeholders and spliced back **verbatim** after translation, so references/links stay intact and are never exposed to the service. Bech32 refs inside URL paths are handled correctly.
- **Bounded client-side cache** — keyed by content + target + endpoint hash, with 200-entry LRU-style eviction.
- **Offer gating** — hidden on entity-only/short notes and non-text kinds (long-form articles, drafts).
- **Graceful failure** — user-friendly error on unreachable/errored service.

## Files

| File | Purpose |
|------|---------|
| `src/lib/translation.ts` | Entity protection (mask/unmask), LibreTranslate API call, bounded cache |
| `src/lib/translationSettings.ts` | User settings persisted in `localStorage` |
| `src/components/NoteTranslate/NoteTranslate.tsx` | Inline Translate/Show-original control (+ `.module.scss`) |
| `src/pages/Settings/Translation.tsx` | Settings → Note Translation page |
| `src/components/Note/Note.tsx` | Wire control below kind-1 notes (primary, feed, thread) |
| `src/Router.tsx` / `src/pages/Settings/Menu.tsx` | Route + nav entry for `/settings/translation` |
| `src/translations.ts` | i18n strings |
| `scripts/check-translation.mjs` | Unit tests (entity round-trip + service module) |

## Verification

- `npm run check:translation` → **17 passed, 0 failed** (mask/unmask round-trip, de-dup, tolerant restore, request shape, response parsing, error paths, cache + bounded eviction)
- `npm run build` → passes
- `npx tsc --noEmit` → clean for all touched files (one pre-existing syntax error in `src/components/PrimalMarkdown/MarkdownEditor.tsx`, unrelated)

## Notes

> This patch was produced with AI assistance and manually reviewed.

Happy to adjust the default endpoint, UX, or cache semantics to match Primal conventions.
