### PR TITLE
Add note translation action

### DIFF
--- a/src/components/Note/NoteContextMenu.tsx
+++ b/src/components/Note/NoteContextMenu.tsx
@@ -15,7 +15,7 @@ import { nip19 } from 'nostr-tools';
 import { readSecFromStorage } from '../../lib/localStore';
 import { useNavigate } from '@solidjs/router';
 import { Kind } from '../../constants';
-import { urlEncode } from '../../utils';
+import { getLang, urlEncode } from '../../utils';
 import { accountStore, addToMuteList, hasPublicKey, removeFromMuteList, setShowPin, showGetStarted } from '../../stores/accountStore';
 
 const NoteContextMenu: Component<{
@@ -150,6 +150,28 @@ const NoteContextMenu: Component<{
     toaster?.sendSuccess(intl.formatMessage(tToast.notePrimalTextCoppied));
   };
 
+  const translateNote = () => {
+    if (!props.data) return;
+
+    const text = [Kind.UserPoll, Kind.ZapPoll].includes(note().msg.kind) ?
+      // @ts-ignore
+      `${note().question || ''}` :
+      `${note().content || ''}`;
+
+    if (text.trim().length === 0) return;
+
+    const targetLang = (getLang() || 'en').split('-')[0];
+    const params = new URLSearchParams({
+      sl: 'auto',
+      tl: targetLang,
+      text,
+      op: 'translate',
+    });
+
+    window.open(`https://translate.google.com/?${params.toString()}`, '_blank', 'noopener,noreferrer');
+    props.onClose();
+  };
+
   const copyNoteId = () => {
     if (!props.data) return;
     navigator.clipboard.writeText(`nostr:${note().noteId}`);
@@ -275,6 +297,11 @@ const NoteContextMenu: Component<{
       {
         label: [Kind.UserPoll, Kind.ZapPoll].includes(props.data?.note?.msg.kind) ? intl.formatMessage(tActions.pollContext.copyText) : intl.formatMessage(tActions.noteContext.copyText),
         action: copyNoteText,
+        icon: 'copy_note_text',
+      },
+      {
+        label: [Kind.UserPoll, Kind.ZapPoll].includes(props.data?.note?.msg.kind) ? intl.formatMessage(tActions.pollContext.translate) : intl.formatMessage(tActions.noteContext.translate),
+        action: translateNote,
         icon: 'copy_note_text',
       },
       {

--- a/src/translations.ts
+++ b/src/translations.ts
@@ -518,6 +518,11 @@ export const actions = {
       defaultMessage: 'Copy Note Text',
       description: 'Label for copy note text from context menu',
     },
+    translate: {
+      id: 'actions.noteContext.translate',
+      defaultMessage: 'Translate Note',
+      description: 'Label for translating note text from context menu',
+    },
     copyId: {
       id: 'actions.noteContext.copyId',
       defaultMessage: 'Copy Note ID',
@@ -614,6 +619,11 @@ export const actions = {
       id: 'actions.noteContext.copytext',
       defaultMessage: 'Copy Poll Question',
       description: 'Label for copy note text from context menu',
+    },
+    translate: {
+      id: 'actions.noteContext.translatePoll',
+      defaultMessage: 'Translate Poll',
+      description: 'Label for translating poll text from context menu',
     },
     copyId: {
       id: 'actions.noteContext.copyId',


### PR DESCRIPTION
Adds a user-triggered Translate action to note and poll context menus.

This keeps the implementation client-side and avoids adding Primal-hosted translation costs. When selected, the action opens Google Translate with source language auto-detection and the browser language as the target language.

Details:
- Adds a Translate Note menu item for regular notes.
- Adds a Translate Poll menu item for poll content.
- Uses the existing browser language helper to choose the target language.
- Does not auto-send post content to a third-party service; translation only happens after the user explicitly chooses the action.

Verification:
- Ran `npm run build` successfully.