### PR TITLE
Fix double encoding of zap nostr parameter

### DIFF
--- a/src/lib/zap.ts
+++ b/src/lib/zap.ts
@@ -98,11 +98,9 @@ export const zapNote = async (
   try {
     const signedEvent = await signEvent(zapReq);
 
-    const event = encodeURIComponent(JSON.stringify(signedEvent));
-
     const url = new URL(callback);
     url.searchParams.set('amount', String(sats));
-    url.searchParams.set('nostr', event);
+    url.searchParams.set('nostr', JSON.stringify(signedEvent));
 
     const r2 = await (await fetch(url.toString())).json();
 
@@ -165,11 +163,9 @@ export const zapArticle = async (
   try {
     const signedEvent = await signEvent(zapReq);
 
-    const event = encodeURIComponent(JSON.stringify(signedEvent));
-
     const url = new URL(callback);
     url.searchParams.set('amount', String(sats));
-    url.searchParams.set('nostr', event);
+    url.searchParams.set('nostr', JSON.stringify(signedEvent));
 
     const r2 = await (await fetch(url.toString())).json();
     const pr = r2.pr;
@@ -223,11 +219,9 @@ export const zapProfile = async (
   try {
     const signedEvent = await signEvent(zapReq);
 
-    const event = encodeURIComponent(JSON.stringify(signedEvent));
-
     const url = new URL(callback);
     url.searchParams.set('amount', String(sats));
-    url.searchParams.set('nostr', event);
+    url.searchParams.set('nostr', JSON.stringify(signedEvent));
 
     const r2 = await (await fetch(url.toString())).json();
 
@@ -300,11 +294,9 @@ export const zapSubscription = async (
   try {
     const signedEvent = await signEvent(zapReq);
 
-    const event = encodeURIComponent(JSON.stringify(signedEvent));
-
     const url = new URL(callback);
     url.searchParams.set('amount', String(sats));
-    url.searchParams.set('nostr', event);
+    url.searchParams.set('nostr', JSON.stringify(signedEvent));
 
     const r2 = await (await fetch(url.toString())).json();
     const pr = r2.pr;
@@ -367,11 +359,9 @@ export const zapDVM = async (
   try {
     const signedEvent = await signEvent(zapReq);
 
-    const event = encodeURIComponent(JSON.stringify(signedEvent));
-
     const url = new URL(callback);
     url.searchParams.set('amount', String(sats));
-    url.searchParams.set('nostr', event);
+    url.searchParams.set('nostr', JSON.stringify(signedEvent));
 
     const r2 = await (await fetch(url.toString())).json();
     const pr = r2.pr;
@@ -434,11 +424,9 @@ export const zapStream = async (
   try {
     const signedEvent = await signEvent(zapReq);
 
-    const event = encodeURIComponent(JSON.stringify(signedEvent));
-
     const url = new URL(callback);
     url.searchParams.set('amount', String(sats));
-    url.searchParams.set('nostr', event);
+    url.searchParams.set('nostr', JSON.stringify(signedEvent));
 
     const r2 = await (await fetch(url.toString())).json();
     const pr = r2.pr;
@@ -566,11 +554,9 @@ export const zapVote = async (
   try {
     const signedEvent = await signEvent(zapReq);
 
-    const event = encodeURIComponent(JSON.stringify(signedEvent));
-
     const url = new URL(callback);
     url.searchParams.set('amount', String(sats));
-    url.searchParams.set('nostr', event);
+    url.searchParams.set('nostr', JSON.stringify(signedEvent));
 
     const r2 = await (await fetch(url.toString())).json();
     const pr = r2.pr;


### PR DESCRIPTION
Fixes #220

Zap requests were encoding the nostr parameter before passing it to
URLSearchParams, which then encoded the value again.

This resulted in values such as %257B... instead of %7B..., causing
LNURL-pay callbacks to receive a percent-encoded string instead of the
expected JSON event after query parsing.

The explicit encodeURIComponent() calls have been removed and
JSON.stringify(signedEvent) is now passed directly to searchParams.set(),
allowing URLSearchParams to handle encoding once.

Applied consistently to all seven zap flows.

### Verification

- Build passes
- Behavior matches NIP-57 encoding requirements  
- All equivalent zap call sites were updated
- Browser E2E was not run in this environment